### PR TITLE
deploy/template/deployment.yaml: remove autoupdate annotation

### DIFF
--- a/deploy/template/deployment.yaml
+++ b/deploy/template/deployment.yaml
@@ -65,8 +65,6 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    rbac.authorization.kubernetes.io/autoupdate: "true"
   name: system:cloud-controller-manager
 rules:
 - apiGroups:


### PR DESCRIPTION
According to Kubernetes documentation, autoupdate is true by default
when RBAC mode is enabled, so this annotation is redundant and can be
removed.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>