### PR TITLE
Makefile: add targets for building multi-arch Docker manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ VERSION := $(RELEASE_TAG)-$(VERSION)
 endif
 GO_FILES := $(shell find . -type f -not -path './vendor/*' -name '*.go')
 BUILD_TAG ?= latest
+TAGGED_IMAGE ?= $(BUILD_IMAGE):$(BUILD_TAG)
+TAGGED_ARCH_IMAGE ?= $(TAGGED_IMAGE)-$(ARCH)
 LDFLAGS ?= -ldflags '-extldflags "-static" -X "$(PACKAGE_NAME)/version.VERSION=$(VERSION)"'
 
 # which arches can we support
@@ -161,8 +163,8 @@ sub-image-%:
 	@$(MAKE) ARCH=$* image
 
 image: ## make the image for a single ARCH
-	docker buildx build --load -t $(BUILD_IMAGE):$(BUILD_TAG)-$(ARCH) -f Dockerfile --platform $(OS)/$(ARCH) .
-	echo "Done. image is at $(BUILD_IMAGE):$(BUILD_TAG)-$(ARCH)"
+	docker buildx build --load -t $(TAGGED_ARCH_IMAGE) -f Dockerfile --platform $(OS)/$(ARCH) .
+	echo "Done. image is at $(TAGGED_ARCH_IMAGE)"
 
 # Targets used when cross building.
 .PHONY: register

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifneq (,$(RELEASE_TAG))
 VERSION := $(RELEASE_TAG)-$(VERSION)
 endif
 GO_FILES := $(shell find . -type f -not -path './vendor/*' -name '*.go')
-FROMTAG ?= latest
+BUILD_TAG ?= latest
 LDFLAGS ?= -ldflags '-extldflags "-static" -X "$(PACKAGE_NAME)/version.VERSION=$(VERSION)"'
 
 # which arches can we support
@@ -161,8 +161,8 @@ sub-image-%:
 	@$(MAKE) ARCH=$* image
 
 image: ## make the image for a single ARCH
-	docker buildx build --load -t $(BUILD_IMAGE):latest-$(ARCH) -f Dockerfile --platform $(OS)/$(ARCH) .
-	echo "Done. image is at $(BUILD_IMAGE):latest-$(ARCH)"
+	docker buildx build --load -t $(BUILD_IMAGE):$(BUILD_TAG)-$(ARCH) -f Dockerfile --platform $(OS)/$(ARCH) .
+	echo "Done. image is at $(BUILD_IMAGE):$(BUILD_TAG)-$(ARCH)"
 
 # Targets used when cross building.
 .PHONY: register


### PR DESCRIPTION
So multi-arch manifests can be also built locally, not only on CI.

One can now run:
```
make image-manifest-all-push BUILD_IMAGE=quay.io/foo/packet-ccm BUILD_TAG=bar
```

To build and push all required images, build the manifest and push it as well.

Closes #104.