### PR TITLE
bump alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.11 as certs
+FROM alpine:3.13 as certs
 
 RUN apk --update add ca-certificates
 
 # builder
-FROM golang:1.15.6-alpine3.12 as build
+FROM golang:1.15.8-alpine3.13 as build
 
 WORKDIR /go/src/app
 RUN apk --update add make git


### PR DESCRIPTION
There have been intermittent build failures, known issues with certain `apk` commands on arm. These don't usually cause a major problem - just rerun the build job - but this helps keep it clean.

It is a good thing on its own merits, anyways.