### PR TITLE
Add backward compatibility for providerID convention

### DIFF
--- a/metal/cloud.go
+++ b/metal/cloud.go
@@ -19,6 +19,11 @@ import (
 
 const (
 	providerName string = "equinixmetal"
+
+	// deprecatedProviderName is used to provide backward compatibility support
+	// with previous versions
+	deprecatedProviderName string = "packet"
+
 	// ConsumerToken token for metal consumer
 	ConsumerToken         string = "cloud-provider-equinix-metal"
 	checkLoopTimerSeconds        = 60

--- a/metal/devices.go
+++ b/metal/devices.go
@@ -228,7 +228,7 @@ func deviceIDFromProviderID(providerID string) (string, error) {
 	switch len(split) {
 	case 2:
 		deviceID = split[1]
-		if split[0] != providerName {
+		if split[0] != providerName && split[0] != deprecatedProviderName {
 			return "", errors.Errorf("provider name from providerID should be %s, was %s", providerName, split[0])
 		}
 	case 1:

--- a/metal/devices_test.go
+++ b/metal/devices_test.go
@@ -91,6 +91,7 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 		{"aws://abcdef5667", nil, fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetal
 		{"equinixmetal://acbdef-56788", nil, fmt.Errorf("instance not found")},                        // unknown ID
 		{fmt.Sprintf("equinixmetal://%s", dev.ID), validAddresses, nil},                               // valid
+		{fmt.Sprintf("packet://%s", dev.ID), validAddresses, nil},                                     // valid
 		{dev.ID, validAddresses, nil},                                                                 // valid
 	}
 
@@ -181,6 +182,7 @@ func TestInstanceTypeByProviderID(t *testing.T) {
 		{"aws://abcdef5667", "", fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetalk
 		{"equinixmetal://acbdef-56788", "", fmt.Errorf("instance not found")},                        // unknown ID
 		{fmt.Sprintf("equinixmetal://%s", dev.ID), dev.Plan.Name, nil},                               // valid
+		{fmt.Sprintf("packet://%s", dev.ID), dev.Plan.Name, nil},                                     // valid
 	}
 
 	for i, tt := range tests {
@@ -238,6 +240,7 @@ func TestInstanceExistsByProviderID(t *testing.T) {
 		{"aws://abcdef5667", false, fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetal
 		{"equinixmetal://acbdef-56788", false, nil},                                                     // unknown ID
 		{fmt.Sprintf("equinixmetal://%s", dev.ID), true, nil},                                           // valid
+		{fmt.Sprintf("packet://%s", dev.ID), true, nil},                                                 // valid
 		{dev.ID, true, nil}, // valid
 	}
 
@@ -276,9 +279,11 @@ func TestInstanceShutdownByProviderID(t *testing.T) {
 		{"aws://abcdef5667", false, fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetal
 		{"equinixmetal://acbdef-56788", false, fmt.Errorf("instance not found")},                        // unknown ID
 		{fmt.Sprintf("equinixmetal://%s", devActive.ID), false, nil},                                    // valid
-		{devActive.ID, false, nil},                                    // valid
-		{fmt.Sprintf("equinixmetal://%s", devInactive.ID), true, nil}, // valid
-		{devInactive.ID, true, nil},                                   // valid
+		{fmt.Sprintf("packet://%s", devActive.ID), false, nil},                                          // valid
+		{devActive.ID, false, nil},                                                                      // valid
+		{fmt.Sprintf("equinixmetal://%s", devInactive.ID), true, nil},                                   // valid
+		{fmt.Sprintf("packet://%s", devInactive.ID), true, nil},                                         // valid
+		{devInactive.ID, true, nil},                                                                     // valid
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Allows matching devices based on the old providerID convention (packet://).

This is to help enable migrating Cluster API-based clusters to newer versions of the CCM.