### PR TITLE
fix handling of metallb custom configmap and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Loadbalancing is enabled as follows.
 1. If the config file has a key named `metalLB`, read that. Else...
 1. Load balancing is disabled.
 
-The value of the loadbalancing configuration is `<type>://<detail>` where:
+The value of the loadbalancing configuration is `<type>:///<detail>` where:
 
 * `<type>` is the named supported type, of one of those listed below
 * `<detail>` is any additional detail needed to configure the implementation, details in the description below
@@ -230,14 +230,16 @@ to route traffic for your services at the Elastic IP to the correct host.
 To enable it, set the configuration `METAL_LB` or config `metalLB` to:
 
 ```
-metallb://<configMapNamespace>:<configMapName>
+metallb:///<configMapNamespace>/<configMapName>
 ```
 
 For example:
 
-* `metallb://metallb-system:config` - enable `metallb` management and update the configmap `config` in the namespace `metallb-system`
-* `metallb://foonamespace:myconfig` -  - enable `metallb` management and update the configmap `myconfig` in the namespace `foonamespae`
-* `metallb://` - enable `metallb` management and update the default configmap, i.e. `config` in the namespace `metallb-system`
+* `metallb:///metallb-system/config` - enable `metallb` management and update the configmap `config` in the namespace `metallb-system`
+* `metallb:///foonamespace/myconfig` -  - enable `metallb` management and update the configmap `myconfig` in the namespace `foonamespae`
+* `metallb:///` - enable `metallb` management and update the default configmap, i.e. `config` in the namespace `metallb-system`
+
+Notice the **three* slashes. In the URL, the namespace and the configmap are in the path.
 
 When enabled, CCM controls the loadbalancer by updating the provided `ConfigMap`.
 

--- a/metal/loadbalancers/metallb/metallb.go
+++ b/metal/loadbalancers/metallb/metallb.go
@@ -28,7 +28,14 @@ type LB struct {
 
 func NewLB(k8sclient kubernetes.Interface, config string) *LB {
 	var configmapnamespace, configmapname string
-	cmparts := strings.SplitN(config, ":", 2)
+	// it may have an extra slash at the beginning or end, so get rid of it
+	if strings.HasPrefix(config, "/") {
+		config = config[1:]
+	}
+	if strings.HasSuffix(config, "/") {
+		config = config[:len(config)-1]
+	}
+	cmparts := strings.SplitN(config, "/", 2)
 	if len(cmparts) >= 2 {
 		configmapnamespace, configmapname = cmparts[0], cmparts[1]
 	}


### PR DESCRIPTION
There were 2 issues:

1. The README didn't make it clear that when providing config for a load balancer, you need to provide everything in path, not host, so, e.g. `metallb:///namespace/configname` and not `metallb://namespace/configname` (three slashes instead of two); fixes the doc
2. Fixes parsing of the above config information, and changes it to use `/` as a separator; `:` causes too many issues, and is un-URL-ish