### PR TITLE
set md5 passphrase base64-encoded in annotations, add to metallb configmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,17 +148,23 @@ This section lists each configuration option, and whether it can be set by each 
 | Facility |    | `METAL_FACILITY_NAME` | `facility` | read metadata on host on which CCM is running, else error |
 | Base URL to Equinix API |    |    | `base-url` | Official Equinix Metal API |
 | Load balancer setting |   | `METAL_LB` | `loadbalancer` | none |
-| BGP ASN for each cluster node |   | `METAL_LOCAL_ASN` | `localASN` | `65000` |
-| BGP ASN for upstream peer |   | `METAL_PEER_ASN` | `peerASN` | `65530` |
+| BGP ASN for cluster nodes when enabling BGP on the project |   | `METAL_LOCAL_ASN` | `localASN` | `65000` |
+| BGP passphrase to use when enabling BGP on the project |   | `METAL_BGP_PASS` | `bgpPass` | `""` |
 | Kubernetes annotation to set node's BGP ASN |   | `METAL_ANNOTATION_LOCAL_ASN` | `annotationLocalASN` | `"metal.equinix.com/node-asn"` |
 | Kubernetes annotation to set BGP peer's ASN |   | `METAL_ANNOTATION_PEER_ASNS` | `annotationPeerASNs` | `"metal.equinix.com/peer-asn"` |
 | Kubernetes annotation to set BGP peer's IPs |   | `METAL_ANNOTATION_PEER_IPS` | `annotationPeerIPs` | `"metal.equinix.com/peer-ip"` |
 | Kubernetes annotation to set source IP for BGP peering |   | `METAL_ANNOTATION_SRC_IP` | `annotationSrcIP` | `"metal.equinix.com/src-ip"` |
-| Kubernetes annotation to set source IP for BGP peering |   | `METAL_ANNOTATION_SRC_IP` | `annotationSrcIP` | `"metal.equinix.com/src-ip"` |
+| Kubernetes annotation to set BGP MD5 password, base64-encoded (see security warning below) |   | `METAL_ANNOTATION_BGP_PASS` | `annotationBGPPass` | `"metal.equinix.com/bgp-pass"` |
 | Tag for control plane Elastic IP |    | `METAL_EIP_TAG` | `eipTag` | No control plane Elastic IP |
 | Kubernetes API server port for Elastic IP |     | `METAL_API_SERVER_PORT` | `apiServerPort` | `6443` |
-| Kubernetes API server port for Elastic IP |     | `METAL_API_SERVER_PORT` | `apiServerPort` | `6443` |
 | Filter for cluster nodes on which to enable BGP |    | `METAL_BGP_NODE_SELECTOR` | `bgpNodeSelector` | All nodes |
+
+<u>Security Warning</u>
+Including your project's BGP password, even base64-encoded, may have security implications. Because Equinix Metal
+only allows communication to the BGP peer from the actual node, and not from outside, and because that password already is available
+form metadata on the host, this risk may be limited. We further recommend using Kubernetes
+[Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) to restrict access to BGP peers solely
+to system pods that have reasonable need to access them.
 
 ## How It Works
 

--- a/main.go
+++ b/main.go
@@ -28,11 +28,12 @@ const (
 	facilityName                 = "METAL_FACILITY_NAME"
 	loadBalancerSettingName      = "METAL_LB"
 	envVarLocalASN               = "METAL_LOCAL_ASN"
-	envVarPeerASN                = "METAL_PEER_ASN"
+	envVarBGPPass                = "METAL_BGP_PASS"
 	envVarAnnotationLocalASN     = "METAL_ANNOTATION_LOCAL_ASN"
 	envVarAnnotationPeerASNs     = "METAL_ANNOTATION_PEER_ASNS"
 	envVarAnnotationPeerIPs      = "METAL_ANNOTATION_PEER_IPS"
 	envVarAnnotationSrcIP        = "METAL_ANNOTATION_SRC_IP"
+	envVarAnnotationBGPPass      = "METAL_ANNOTATION_BGP_PASS"
 	envVarEIPTag                 = "METAL_EIP_TAG"
 	envVarAPIServerPort          = "METAL_API_SERVER_PORT"
 	envVarBGPNodeSelector        = "METAL_BGP_NODE_SELECTOR"
@@ -157,19 +158,9 @@ func getMetalConfig(providerConfig string) (metal.Config, error) {
 		config.LocalASN = metal.DefaultLocalASN
 	}
 
-	// get the peer ASN
-	peerASN := os.Getenv(envVarPeerASN)
-	switch {
-	case peerASN != "":
-		peerASNNo, err := strconv.Atoi(peerASN)
-		if err != nil {
-			return config, fmt.Errorf("env var %s must be a number, was %s: %v", envVarPeerASN, peerASN, err)
-		}
-		config.PeerASN = peerASNNo
-	case rawConfig.PeerASN != 0:
-		config.PeerASN = rawConfig.PeerASN
-	default:
-		config.PeerASN = metal.DefaultPeerASN
+	bgpPass := os.Getenv(envVarBGPPass)
+	if bgpPass != "" {
+		config.BGPPass = bgpPass
 	}
 
 	// set the annotations
@@ -192,6 +183,12 @@ func getMetalConfig(providerConfig string) (metal.Config, error) {
 	annotationSrcIP := os.Getenv(envVarAnnotationSrcIP)
 	if annotationSrcIP != "" {
 		config.AnnotationSrcIP = annotationSrcIP
+	}
+
+	config.AnnotationBGPPass = metal.DefaultAnnotationBGPPass
+	annotationBGPPass := os.Getenv(envVarAnnotationBGPPass)
+	if annotationBGPPass != "" {
+		config.AnnotationBGPPass = annotationBGPPass
 	}
 
 	if rawConfig.EIPTag != "" {

--- a/metal/cloud.go
+++ b/metal/cloud.go
@@ -72,8 +72,8 @@ func newCloud(metalConfig Config, client *packngo.Client) (cloudprovider.Interfa
 		facility:                    metalConfig.Facility,
 		instances:                   i,
 		zones:                       newZones(client, metalConfig.ProjectID),
-		loadBalancer:                newLoadBalancers(client, metalConfig.ProjectID, metalConfig.Facility, metalConfig.LoadBalancerSetting, metalConfig.LocalASN, metalConfig.PeerASN),
-		bgp:                         newBGP(client, metalConfig.ProjectID, metalConfig.LocalASN, metalConfig.PeerASN, metalConfig.AnnotationLocalASN, metalConfig.AnnotationPeerASNs, metalConfig.AnnotationPeerIPs, metalConfig.AnnotationSrcIP, metalConfig.BGPNodeSelector),
+		loadBalancer:                newLoadBalancers(client, metalConfig.ProjectID, metalConfig.Facility, metalConfig.LoadBalancerSetting),
+		bgp:                         newBGP(client, metalConfig.ProjectID, metalConfig.LocalASN, metalConfig.BGPPass, metalConfig.AnnotationLocalASN, metalConfig.AnnotationPeerASNs, metalConfig.AnnotationPeerIPs, metalConfig.AnnotationSrcIP, metalConfig.AnnotationBGPPass, metalConfig.BGPNodeSelector),
 		controlPlaneEndpointManager: newControlPlaneEndpointManager(metalConfig.EIPTag, metalConfig.ProjectID, client.DeviceIPs, client.ProjectIPs, i, metalConfig.APIServerPort),
 	}, nil
 }

--- a/metal/config.go
+++ b/metal/config.go
@@ -9,12 +9,13 @@ type Config struct {
 	BaseURL             *string `json:"base-url,omitempty"`
 	LoadBalancerSetting string  `json:"loadbalancer"`
 	Facility            string  `json:"facility,omitempty"`
-	PeerASN             int     `json:"peerASN,omitempty"`
 	LocalASN            int     `json:"localASN,omitempty"`
+	BGPPass             string  `json:"bgpPass,omitempty"`
 	AnnotationLocalASN  string  `json:"annotationLocalASN,omitEmpty"`
 	AnnotationPeerASNs  string  `json:"annotationPeerASNs,omitEmpty"`
 	AnnotationPeerIPs   string  `json:"annotationPeerIPs,omitEmpty"`
 	AnnotationSrcIP     string  `json:"annotationSrcIP,omitEmpty"`
+	AnnotationBGPPass   string  `json:"annotationBGPPass,omitEmpty"`
 	EIPTag              string  `json:"eipTag,omitEmpty"`
 	APIServerPort       int     `json:"apiServerPort,omitEmpty"`
 	BGPNodeSelector     string  `json:"bgpNodeSelector,omitEmpty"`
@@ -37,7 +38,6 @@ func (c Config) Strings() []string {
 		ret = append(ret, "load balancer config: ''%s", c.LoadBalancerSetting)
 	}
 	ret = append(ret, fmt.Sprintf("facility: '%s'", c.Facility))
-	ret = append(ret, fmt.Sprintf("peer ASN: '%d'", c.PeerASN))
 	ret = append(ret, fmt.Sprintf("local ASN: '%d'", c.LocalASN))
 	ret = append(ret, fmt.Sprintf("Elastic IP Tag: '%s'", c.EIPTag))
 	ret = append(ret, fmt.Sprintf("API Server Port: '%d'", c.APIServerPort))

--- a/metal/constants.go
+++ b/metal/constants.go
@@ -10,6 +10,7 @@ const (
 	DefaultAnnotationPeerASNs = "metal.equinix.com/peer-asn"
 	DefaultAnnotationPeerIPs  = "metal.equinix.com/peer-ip"
 	DefaultAnnotationSrcIP    = "metal.equinix.com/src-ip"
+	DefaultAnnotationBGPPass  = "metal.equinix.com/bgp-pass"
 	DefaultLocalASN           = 65000
 	DefaultPeerASN            = 65530
 	DefaultAPIServerPort      = 6443

--- a/metal/loadbalancers/empty/empty.go
+++ b/metal/loadbalancers/empty/empty.go
@@ -28,7 +28,7 @@ func (l *LB) SyncServices(ctx context.Context, ips map[string]bool) error {
 }
 
 // AddNode add a node with the provided name, srcIP, and bgp information
-func (l *LB) AddNode(ctx context.Context, nodeName string, localASN, peerASN int, srcIP string, peers ...string) error {
+func (l *LB) AddNode(ctx context.Context, nodeName string, localASN, peerASN int, password, srcIP string, peers ...string) error {
 	return nil
 }
 

--- a/metal/loadbalancers/interface.go
+++ b/metal/loadbalancers/interface.go
@@ -6,7 +6,7 @@ import (
 
 type LB interface {
 	// AddNode add a node with the provided name, srcIP, and bgp information
-	AddNode(ctx context.Context, nodeName string, localASN, peerASN int, srcIP string, peers ...string) error
+	AddNode(ctx context.Context, nodeName string, localASN, peerASN int, pass string, srcIP string, peers ...string) error
 	// RemoveNode remove a node with the provided name
 	RemoveNode(ctx context.Context, nodeName string) error
 	// SyncNodes ensure that the list of nodes is only those with the matched names

--- a/metal/loadbalancers/kubevip/kubevip.go
+++ b/metal/loadbalancers/kubevip/kubevip.go
@@ -28,7 +28,7 @@ func (l *LB) SyncServices(ctx context.Context, ips map[string]bool) error {
 }
 
 // AddNode add a node with the provided name, srcIP, and bgp information
-func (l *LB) AddNode(ctx context.Context, nodeName string, localASN, peerASN int, srcIP string, peers ...string) error {
+func (l *LB) AddNode(ctx context.Context, nodeName string, localASN, peerASN int, password, srcIP string, peers ...string) error {
 	return nil
 }
 

--- a/metal/loadbalancers/metallb/metallb.go
+++ b/metal/loadbalancers/metallb/metallb.go
@@ -96,7 +96,7 @@ func (l *LB) SyncServices(ctx context.Context, ips map[string]bool) error {
 }
 
 // AddNode add a node with the provided name, srcIP, and bgp information
-func (l *LB) AddNode(ctx context.Context, nodeName string, localASN, peerASN int, srcIP string, peers ...string) error {
+func (l *LB) AddNode(ctx context.Context, nodeName string, localASN, peerASN int, password, srcIP string, peers ...string) error {
 	config, err := l.getConfigMap(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to retrieve metallb config map %s:%s : %v", l.configMapNamespace, l.configMapName, err)
@@ -112,6 +112,7 @@ func (l *LB) AddNode(ctx context.Context, nodeName string, localASN, peerASN int
 		p := Peer{
 			MyASN:         uint32(localASN),
 			ASN:           uint32(peerASN),
+			Password:      password,
 			Addr:          peer,
 			NodeSelectors: []NodeSelector{ns},
 		}
@@ -174,7 +175,7 @@ func (l *LB) SyncNodes(ctx context.Context, nodes map[string]loadbalancers.Node)
 	}
 	for _, node := range nodes {
 		if _, ok := configMap[node.Name]; !ok {
-			if err := l.AddNode(ctx, node.Name, node.LocalASN, node.PeerASN, node.SourceIP, node.Peers...); err != nil {
+			if err := l.AddNode(ctx, node.Name, node.LocalASN, node.PeerASN, node.Password, node.SourceIP, node.Peers...); err != nil {
 				klog.V(2).Infof("loadbalancers.reconcileNodes(): error adding node %s: %v", node.Name, err)
 				continue
 			}

--- a/metal/loadbalancers/node.go
+++ b/metal/loadbalancers/node.go
@@ -5,5 +5,6 @@ type Node struct {
 	SourceIP string
 	LocalASN int
 	PeerASN  int
+	Password string
 	Peers    []string
 }


### PR DESCRIPTION
I am not done with testing this yet, but it is ready for eyes-on review.

This places the md5 password string, however it appears when getting device info from the Equinix Metal API, in a few places:

* an annotation, base64-encoded. This doesn't provide real security, but it is better than being able to see it at a glance.
* in the metallb configmap in the right place for the peer

It also adds supportive details:  an env var for configuring the annotation name, a default annotation name, documentation of the above.

It also cleans up the README a bit: removing a duplicate entry in the configuration table, and clarifies that the env var for local ASN and BGP password are solely for requesting it when enabling on the project; when actually setting it on nodes, it uses the ones retrieved from the EM API. This behaviour is unchanged; just docs clarification of the above.

cc @enkelprifti98 