### PR TITLE
configure EIP port and healthcheck ports from existing service with env var override

### DIFF
--- a/main.go
+++ b/main.go
@@ -206,11 +206,12 @@ func getMetalConfig(providerConfig string) (metal.Config, error) {
 		if err != nil {
 			return config, fmt.Errorf("env var %s must be a number, was %s: %v", envVarAPIServerPort, apiServer, err)
 		}
-		config.APIServerPort = apiServerNo
+		config.APIServerPort = int32(apiServerNo)
 	case rawConfig.APIServerPort != 0:
 		config.APIServerPort = rawConfig.APIServerPort
 	default:
-		config.APIServerPort = metal.DefaultAPIServerPort
+		// if nothing else set it, we set it to 0, to indicate that it should use whatever the kube-apiserver port is
+		config.APIServerPort = 0
 	}
 
 	config.BGPNodeSelector = rawConfig.BGPNodeSelector

--- a/metal/config.go
+++ b/metal/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	AnnotationSrcIP     string  `json:"annotationSrcIP,omitEmpty"`
 	AnnotationBGPPass   string  `json:"annotationBGPPass,omitEmpty"`
 	EIPTag              string  `json:"eipTag,omitEmpty"`
-	APIServerPort       int     `json:"apiServerPort,omitEmpty"`
+	APIServerPort       int32   `json:"apiServerPort,omitEmpty"`
 	BGPNodeSelector     string  `json:"bgpNodeSelector,omitEmpty"`
 }
 

--- a/metal/constants.go
+++ b/metal/constants.go
@@ -13,5 +13,4 @@ const (
 	DefaultAnnotationBGPPass  = "metal.equinix.com/bgp-pass"
 	DefaultLocalASN           = 65000
 	DefaultPeerASN            = 65530
-	DefaultAPIServerPort      = 6443
 )


### PR DESCRIPTION
Fixes #171 

Affects only control plane EIP assignment.

Before this change:

* EIP port always is set to 443
* Healthchecks on EIP port defaults to 6443, able to override via env var `METAL_API_SERVER_PORT` (which always has to be set to match 443)
* Healthchecks on control plane nodes always check on port 6443, no matter what the kube-apiserver actually is listening on

After this change:

* EIP port is set via env var `METAL_API_SERVER_PORT`; if it is not set, or is `0`, use the same port as the `kube-apiserver`
* Healthchecks on EIP port match the previous line
* Healthchecks on control plane nodes are set to whatever port the `kube-apiserver` is listening on, determined by checking the Kubernetes service `default/kubernetes`