### PR TITLE
exempt controlplane Service from loadbalancer management

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,8 @@ nodes. The CCM does the following on each loop:
 
 This has the following effect:
 
-* the annotation prevents metallb from trying to manage it
+* the annotation prevents metallb from trying to manage the IP
+* the name prevents CCM from passing it to the loadbalancer provider address mapping, thus preventing any of them from managing it
 * the `spec.loadBalancerIP` and `status.loadBalancer.ingress[0].ip` cause kube-proxy to set up routes on all of the nodes
 * the endpoints cause the traffic to be routed to the control plane nodes
 

--- a/metal/eip_controlplane_reconciliation.go
+++ b/metal/eip_controlplane_reconciliation.go
@@ -361,10 +361,12 @@ func (m *controlPlaneEndpointManager) reconcileServices(ctx context.Context, svc
 				},
 			},
 		}
-		if _, err := svcIntf.UpdateStatus(ctx, updatedService, metav1.UpdateOptions{}); err != nil {
+		var updatedService2 *v1.Service
+		if updatedService2, err = svcIntf.UpdateStatus(ctx, updatedService, metav1.UpdateOptions{}); err != nil {
 			klog.Errorf("failed to update service status: %v", err)
 			return fmt.Errorf("failed to update service status: %v", err)
 		}
+		klog.V(5).Infof("updated service after status update: %#v", updatedService2)
 		return nil
 	}
 	// every sync should find default/kubernetes

--- a/metal/loadbalancers.go
+++ b/metal/loadbalancers.go
@@ -207,9 +207,14 @@ func (l *loadBalancers) reconcileServices(ctx context.Context, svcs []*v1.Servic
 	validSvcs := []*v1.Service{}
 	for _, svc := range svcs {
 		// filter on type: only take those that are of type=LoadBalancer
-		if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
-			validSvcs = append(validSvcs, svc)
+		if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+			continue
 		}
+		// filter on name: do not try to manage the the service we created for EIP load balancer
+		if svc.ObjectMeta.Name == externalServiceName && svc.ObjectMeta.Namespace == externalServiceNamespace {
+			continue
+		}
+		validSvcs = append(validSvcs, svc)
 	}
 	klog.V(5).Infof("loadbalancer.reconcileServices(): valid services %#v", validSvcs)
 


### PR DESCRIPTION
Fixes #174 

Ensures that the special `Service` for the control plane EIP does not try to get managed by the load balancer.