### PR TITLE
Add permission to read and update events

### DIFF
--- a/deploy/chart/templates/clusterrole.yaml
+++ b/deploy/chart/templates/clusterrole.yaml
@@ -70,4 +70,15 @@ rules:
       - watch
       - update
       - patch
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
 {{- end }}

--- a/deploy/template/deployment.yaml
+++ b/deploy/template/deployment.yaml
@@ -135,6 +135,18 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  # reason: so ccm can read and update events
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Permission to read and update events is needed for the CCM otherwise logs will show errors trying to read events when a new  LoadBalancer service has been created.