### PR TITLE
add annotation for private network

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ This section lists each configuration option, and whether it can be set by each 
 | Kubernetes annotation to set BGP peer's IPs |   | `METAL_ANNOTATION_PEER_IPS` | `annotationPeerIPs` | `"metal.equinix.com/peer-ip"` |
 | Kubernetes annotation to set source IP for BGP peering |   | `METAL_ANNOTATION_SRC_IP` | `annotationSrcIP` | `"metal.equinix.com/src-ip"` |
 | Kubernetes annotation to set BGP MD5 password, base64-encoded (see security warning below) |   | `METAL_ANNOTATION_BGP_PASS` | `annotationBGPPass` | `"metal.equinix.com/bgp-pass"` |
+| Kubernetes annotation to set the CIDR for the network range of the private address |  | `METAL_ANNOTATION_NETWORK_IPV4_ PRIVATE` |  `annotationNetworkIPv4Private` | `metal.equinix.com/network/4/private` |
 | Tag for control plane Elastic IP |    | `METAL_EIP_TAG` | `eipTag` | No control plane Elastic IP |
 | Kubernetes API server port for Elastic IP |     | `METAL_API_SERVER_PORT` | `apiServerPort` | Same as `kube-apiserver` on control plane nodes, same as `0` |
 | Filter for cluster nodes on which to enable BGP |    | `METAL_BGP_NODE_SELECTOR` | `bgpNodeSelector` | All nodes |
@@ -524,13 +525,15 @@ _not_ recommended to override them. However, you can do so, using the options in
 Set of servers on which BGP will be enabled can be filtered as well, using the the options in [Configuration][Configuration].
 Value for node selector should be a valid Kubernetes label selector (e.g. key1=value1,key2=value2).
 
-In addition to enabling BGP and setting ASNs, the Equinix Metal CCM sets Kubernetes annotations on each cluster node.
-It sets annotations for:
+## Node Annotations
+
+The Equinix Metal CCM sets Kubernetes annotations on each cluster node:
 
 * Node, or local, ASN, default annotation `metal.equinix.com/node-asn`
 * Peer ASNs, comma-separated if multiple, default annotation `metal.equinix.com/peer-asns`
 * Peer IPs, comma-separated if multiple, default annotation `metal.equinix.com/peer-ips`
 * Source IP to use when communicating with upstream peers, default annotation `metal.equinix.com/src-ip`
+* CIDR of the private network range in the project which this node is part of, default annotation `metal.equinix.com/network-ipv4/private`
 
 These annotation names can be overridden, if you so choose, using the options in [Configuration][Configuration].
 

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -119,7 +119,7 @@ configSecret:
   name: ""
 
 # -- Application configuration.
-config: 
+config:
   apiKey: ""
   projectID: ""
   # facility: facility
@@ -132,6 +132,7 @@ config:
   # annotationPeerIPs: "metal.equinix.com/peer-ip"
   # annotationSrcIP: "metal.equinix.com/src-ip"
   # annotationBGPPass: "metal.equinix.com/bgp-pass"
+  # annotationNetworkIPv4Private: `metal.equinix.com/network/4/private`
   # eipTag: ""
   # apiServerPort: 6443
   # bgpNodeSelector: ""

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-hclog v0.12.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/packethost/packet-api-server v0.0.0-20200706140707-f0f79ef89944
-	github.com/packethost/packngo v0.5.1
+	github.com/packethost/packngo v0.17.0
 	github.com/pallinder/go-randomdata v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -474,6 +474,8 @@ github.com/packethost/packngo v0.2.1-0.20200629161839-1810e48469b4 h1:T6L0ioYOSz
 github.com/packethost/packngo v0.2.1-0.20200629161839-1810e48469b4/go.mod h1:erURcsqYzwc9wSb04TX4so+s6F3uZtbXUil0W1LCGHA=
 github.com/packethost/packngo v0.5.1 h1:y+jWcMnyArP3hVZRsBkAXTLhokuqdYg6JUmkshX2SMk=
 github.com/packethost/packngo v0.5.1/go.mod h1:aRxUEV1TprXVcWr35v8tNYgZMjv7FHaInXx224vF2fc=
+github.com/packethost/packngo v0.17.0 h1:fGPlj9NDt6ejOrAMfUgx955oCaR1QBKA9pec14m0L38=
+github.com/packethost/packngo v0.17.0/go.mod h1:YrtUNN9IRjjqN6zK+cy2IYoi3EjHfoWTWxJkI1I1Vk0=
 github.com/pallinder/go-randomdata v1.2.0 h1:EJPxw+sgM1mbMW8RBu5zkG4FbloJpDOCCqPccdWto8A=
 github.com/pallinder/go-randomdata v1.2.0/go.mod h1:p8CasZQiWDLuaKy5ihVvdshqc7LlL6ovmRxAuNXgi3U=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/main.go
+++ b/main.go
@@ -23,21 +23,22 @@ import (
 )
 
 const (
-	apiKeyName                   = "METAL_API_KEY"
-	projectIDName                = "METAL_PROJECT_ID"
-	facilityName                 = "METAL_FACILITY_NAME"
-	loadBalancerSettingName      = "METAL_LOAD_BALANCER"
-	envVarLocalASN               = "METAL_LOCAL_ASN"
-	envVarBGPPass                = "METAL_BGP_PASS"
-	envVarAnnotationLocalASN     = "METAL_ANNOTATION_LOCAL_ASN"
-	envVarAnnotationPeerASNs     = "METAL_ANNOTATION_PEER_ASNS"
-	envVarAnnotationPeerIPs      = "METAL_ANNOTATION_PEER_IPS"
-	envVarAnnotationSrcIP        = "METAL_ANNOTATION_SRC_IP"
-	envVarAnnotationBGPPass      = "METAL_ANNOTATION_BGP_PASS"
-	envVarEIPTag                 = "METAL_EIP_TAG"
-	envVarAPIServerPort          = "METAL_API_SERVER_PORT"
-	envVarBGPNodeSelector        = "METAL_BGP_NODE_SELECTOR"
-	defaultLoadBalancerConfigMap = "metallb-system:config"
+	apiKeyName                         = "METAL_API_KEY"
+	projectIDName                      = "METAL_PROJECT_ID"
+	facilityName                       = "METAL_FACILITY_NAME"
+	loadBalancerSettingName            = "METAL_LOAD_BALANCER"
+	envVarLocalASN                     = "METAL_LOCAL_ASN"
+	envVarBGPPass                      = "METAL_BGP_PASS"
+	envVarAnnotationLocalASN           = "METAL_ANNOTATION_LOCAL_ASN"
+	envVarAnnotationPeerASNs           = "METAL_ANNOTATION_PEER_ASNS"
+	envVarAnnotationPeerIPs            = "METAL_ANNOTATION_PEER_IPS"
+	envVarAnnotationSrcIP              = "METAL_ANNOTATION_SRC_IP"
+	envVarAnnotationBGPPass            = "METAL_ANNOTATION_BGP_PASS"
+	envVarAnnotationNetworkIPv4Private = "METAL_ANNOTATION_NETWORK_IPV4_PRIVATE"
+	envVarEIPTag                       = "METAL_EIP_TAG"
+	envVarAPIServerPort                = "METAL_API_SERVER_PORT"
+	envVarBGPNodeSelector              = "METAL_BGP_NODE_SELECTOR"
+	defaultLoadBalancerConfigMap       = "metallb-system:config"
 )
 
 var (
@@ -189,6 +190,12 @@ func getMetalConfig(providerConfig string) (metal.Config, error) {
 	annotationBGPPass := os.Getenv(envVarAnnotationBGPPass)
 	if annotationBGPPass != "" {
 		config.AnnotationBGPPass = annotationBGPPass
+	}
+
+	config.AnnotationNetworkIPv4Private = metal.DefaultAnnotationNetworkIPv4Private
+	annotationNetworkIPv4Private := os.Getenv(envVarAnnotationNetworkIPv4Private)
+	if annotationNetworkIPv4Private != "" {
+		config.AnnotationNetworkIPv4Private = annotationNetworkIPv4Private
 	}
 
 	if rawConfig.EIPTag != "" {

--- a/metal/cloud.go
+++ b/metal/cloud.go
@@ -66,7 +66,7 @@ type cloud struct {
 }
 
 func newCloud(metalConfig Config, client *packngo.Client) (cloudprovider.Interface, error) {
-	i := newInstances(client, metalConfig.ProjectID)
+	i := newInstances(client, metalConfig.ProjectID, metalConfig.AnnotationNetworkIPv4Private)
 	return &cloud{
 		client:                      client,
 		facility:                    metalConfig.Facility,

--- a/metal/cloud_test.go
+++ b/metal/cloud_test.go
@@ -173,8 +173,8 @@ func constructClient(authToken string, baseURL *string) *packngo.Client {
 	// client.Transport = logging.NewTransport("EquinixMetal", client.Transport)
 	if baseURL != nil {
 		// really should handle error, but packngo does not distinguish now or handle errors, so ignoring for now
-		client, _ := packngo.NewClientWithBaseURL(ConsumerToken, authToken, client, *baseURL)
+		client, _ := packngo.NewClientWithBaseURL(ConsumerToken, authToken, client.StandardClient(), *baseURL)
 		return client
 	}
-	return packngo.NewClientWithAuth(ConsumerToken, authToken, client)
+	return packngo.NewClientWithAuth(ConsumerToken, authToken, client.StandardClient())
 }

--- a/metal/config.go
+++ b/metal/config.go
@@ -4,21 +4,22 @@ import "fmt"
 
 // Config configuration for a provider, includes authentication token, project ID ID, and optional override URL to talk to a different Equinix Metal API endpoint
 type Config struct {
-	AuthToken           string  `json:"apiKey"`
-	ProjectID           string  `json:"projectId"`
-	BaseURL             *string `json:"base-url,omitempty"`
-	LoadBalancerSetting string  `json:"loadbalancer"`
-	Facility            string  `json:"facility,omitempty"`
-	LocalASN            int     `json:"localASN,omitempty"`
-	BGPPass             string  `json:"bgpPass,omitempty"`
-	AnnotationLocalASN  string  `json:"annotationLocalASN,omitEmpty"`
-	AnnotationPeerASNs  string  `json:"annotationPeerASNs,omitEmpty"`
-	AnnotationPeerIPs   string  `json:"annotationPeerIPs,omitEmpty"`
-	AnnotationSrcIP     string  `json:"annotationSrcIP,omitEmpty"`
-	AnnotationBGPPass   string  `json:"annotationBGPPass,omitEmpty"`
-	EIPTag              string  `json:"eipTag,omitEmpty"`
-	APIServerPort       int32   `json:"apiServerPort,omitEmpty"`
-	BGPNodeSelector     string  `json:"bgpNodeSelector,omitEmpty"`
+	AuthToken                    string  `json:"apiKey"`
+	ProjectID                    string  `json:"projectId"`
+	BaseURL                      *string `json:"base-url,omitempty"`
+	LoadBalancerSetting          string  `json:"loadbalancer"`
+	Facility                     string  `json:"facility,omitempty"`
+	LocalASN                     int     `json:"localASN,omitempty"`
+	BGPPass                      string  `json:"bgpPass,omitempty"`
+	AnnotationLocalASN           string  `json:"annotationLocalASN,omitEmpty"`
+	AnnotationPeerASNs           string  `json:"annotationPeerASNs,omitEmpty"`
+	AnnotationPeerIPs            string  `json:"annotationPeerIPs,omitEmpty"`
+	AnnotationSrcIP              string  `json:"annotationSrcIP,omitEmpty"`
+	AnnotationBGPPass            string  `json:"annotationBGPPass,omitEmpty"`
+	AnnotationNetworkIPv4Private string  `json:"annotationNetworkIPv4Private,omitEmpty"`
+	EIPTag                       string  `json:"eipTag,omitEmpty"`
+	APIServerPort                int32   `json:"apiServerPort,omitEmpty"`
+	BGPNodeSelector              string  `json:"bgpNodeSelector,omitEmpty"`
 }
 
 // String converts the Config structure to a string, while masking hidden fields.

--- a/metal/constants.go
+++ b/metal/constants.go
@@ -1,16 +1,17 @@
 package metal
 
 const (
-	configMapResource         = "configmaps"
-	hostnameKey               = "kubernetes.io/hostname"
-	emIdentifier              = "cloud-provider-equinix-metal-auto"
-	emTag                     = "usage=" + emIdentifier
-	ccmIPDescription          = "Equinix Metal Kubernetes CCM auto-generated for Load Balancer"
-	DefaultAnnotationNodeASN  = "metal.equinix.com/node-asn"
-	DefaultAnnotationPeerASNs = "metal.equinix.com/peer-asn"
-	DefaultAnnotationPeerIPs  = "metal.equinix.com/peer-ip"
-	DefaultAnnotationSrcIP    = "metal.equinix.com/src-ip"
-	DefaultAnnotationBGPPass  = "metal.equinix.com/bgp-pass"
-	DefaultLocalASN           = 65000
-	DefaultPeerASN            = 65530
+	configMapResource                   = "configmaps"
+	hostnameKey                         = "kubernetes.io/hostname"
+	emIdentifier                        = "cloud-provider-equinix-metal-auto"
+	emTag                               = "usage=" + emIdentifier
+	ccmIPDescription                    = "Equinix Metal Kubernetes CCM auto-generated for Load Balancer"
+	DefaultAnnotationNodeASN            = "metal.equinix.com/node-asn"
+	DefaultAnnotationPeerASNs           = "metal.equinix.com/peer-asn"
+	DefaultAnnotationPeerIPs            = "metal.equinix.com/peer-ip"
+	DefaultAnnotationSrcIP              = "metal.equinix.com/src-ip"
+	DefaultAnnotationBGPPass            = "metal.equinix.com/bgp-pass"
+	DefaultAnnotationNetworkIPv4Private = "metal.equinix.com/network/4/private"
+	DefaultLocalASN                     = 65000
+	DefaultPeerASN                      = 65530
 )

--- a/metal/devices.go
+++ b/metal/devices.go
@@ -2,6 +2,7 @@ package metal
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -17,12 +18,14 @@ import (
 )
 
 type instances struct {
-	client  *packngo.Client
-	project string
+	client            *packngo.Client
+	k8sclient         kubernetes.Interface
+	project           string
+	annotationNetwork string
 }
 
-func newInstances(client *packngo.Client, projectID string) *instances {
-	return &instances{client, projectID}
+func newInstances(client *packngo.Client, project, annotationNetwork string) *instances {
+	return &instances{client: client, project: project, annotationNetwork: annotationNetwork}
 }
 
 // cloudService implementation
@@ -30,10 +33,11 @@ func (i *instances) name() string {
 	return "instances"
 }
 func (i *instances) init(k8sclient kubernetes.Interface) error {
+	i.k8sclient = k8sclient
 	return nil
 }
 func (i *instances) nodeReconciler() nodeReconciler {
-	return nil
+	return i.reconcileNodes
 }
 func (i *instances) serviceReconciler() serviceReconciler {
 	return nil
@@ -251,4 +255,85 @@ func (i *instances) deviceFromProviderID(providerID string) (*packngo.Device, er
 	}
 
 	return deviceByID(i.client, id)
+}
+
+// reconcileNodes ensures each node has the annotations it needs
+func (i *instances) reconcileNodes(ctx context.Context, nodes []*v1.Node, mode UpdateMode) error {
+	nodeNames := []string{}
+	for _, node := range nodes {
+		nodeNames = append(nodeNames, node.Name)
+	}
+	klog.V(2).Infof("devices.reconcileNodes(): called for nodes %v", nodeNames)
+	// whether adding or syncing, we just enable bgp. Nothing to do when we remove.
+	switch mode {
+	case ModeAdd, ModeSync:
+		for _, node := range nodes {
+			klog.V(2).Infof("instances.reconcileNodes(): add node %s", node.Name)
+			// get the node provider ID
+			id := node.Spec.ProviderID
+			if id == "" {
+				return fmt.Errorf("no provider ID given")
+			}
+
+			// add annotations
+			klog.V(2).Infof("instances.reconcileNodes(): setting annotations on node %s", node.Name)
+			// get the network info
+			network, err := getNodePrivateNetwork(id, i.client)
+			if err != nil || network == "" {
+				klog.Errorf("instances.reconcileNodes(): could not get private network info for node %s: %v", node.Name, err)
+			} else {
+				newAnnotations := make(map[string]string)
+				oldAnnotations := node.Annotations
+				if oldAnnotations == nil {
+					oldAnnotations = make(map[string]string)
+				}
+				val, ok := oldAnnotations[i.annotationNetwork]
+				if !ok || val != network {
+					newAnnotations[i.annotationNetwork] = network
+				}
+
+				// patch the node with the new annotations
+				if len(newAnnotations) > 0 {
+					mergePatch, _ := json.Marshal(map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": newAnnotations,
+						},
+					})
+
+					if err := patchUpdatedNode(ctx, node.Name, mergePatch, i.k8sclient); err != nil {
+						klog.Errorf("instances.reconcileNodes(): failed to save updated node with annotations %s: %v", node.Name, err)
+					} else {
+						klog.V(2).Infof("instances.reconcileNodes(): annotations set on node %s", node.Name)
+					}
+				} else {
+					klog.V(2).Infof("instances.reconcileNodes(): no change to annotations for %s", node.Name)
+				}
+			}
+		}
+	case ModeRemove:
+		klog.V(2).Info("instances.reconcileNodes(): nothing to do for removing nodes")
+	}
+	klog.V(2).Info("instances.reconcileNodes(): complete")
+	return nil
+}
+
+// getNodePrivateNetwork use the Equinix Metal API to get the CIDR of the private network given a providerID.
+func getNodePrivateNetwork(deviceID string, client *packngo.Client) (string, error) {
+	device, _, err := client.Devices.Get(deviceID, &packngo.GetOptions{Includes: []string{"ip_addresses.parent_block,parent_block"}})
+
+	if err != nil {
+		return "", err
+	}
+	for _, net := range device.Network {
+		// we only want the private, management, ipv4 network
+		if net.Public || !net.Management || net.AddressFamily != 4 {
+			continue
+		}
+		parent := net.ParentBlock
+		if parent == nil || parent.Network == "" || parent.CIDR == 0 {
+			return "", fmt.Errorf("no network information provided for private address %s", net.String())
+		}
+		return fmt.Sprintf("%s/%d", parent.Network, parent.CIDR), nil
+	}
+	return "", nil
 }


### PR DESCRIPTION
In addition to the BGP annotations we already use. This came as an outgrowth of Gardener work, but I started seeing other potential use cases. In any case, the right place to do this is CPEM.

@displague I know this will cause you to have to rebase your big PR; sorry about that. this was getting in the way of some other work.