### PR TITLE
fix: use format supported by Kubernetes annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ This section lists each configuration option, and whether it can be set by each 
 | Kubernetes annotation to set BGP peer's IPs |   | `METAL_ANNOTATION_PEER_IPS` | `annotationPeerIPs` | `"metal.equinix.com/peer-ip"` |
 | Kubernetes annotation to set source IP for BGP peering |   | `METAL_ANNOTATION_SRC_IP` | `annotationSrcIP` | `"metal.equinix.com/src-ip"` |
 | Kubernetes annotation to set BGP MD5 password, base64-encoded (see security warning below) |   | `METAL_ANNOTATION_BGP_PASS` | `annotationBGPPass` | `"metal.equinix.com/bgp-pass"` |
-| Kubernetes annotation to set the CIDR for the network range of the private address |  | `METAL_ANNOTATION_NETWORK_IPV4_ PRIVATE` |  `annotationNetworkIPv4Private` | `metal.equinix.com/network/4/private` |
+| Kubernetes annotation to set the CIDR for the network range of the private address |  | `METAL_ANNOTATION_NETWORK_IPV4_PRIVATE` |  `annotationNetworkIPv4Private` | `metal.equinix.com/network-4-private` |
 | Tag for control plane Elastic IP |    | `METAL_EIP_TAG` | `eipTag` | No control plane Elastic IP |
 | Kubernetes API server port for Elastic IP |     | `METAL_API_SERVER_PORT` | `apiServerPort` | Same as `kube-apiserver` on control plane nodes, same as `0` |
 | Filter for cluster nodes on which to enable BGP |    | `METAL_BGP_NODE_SELECTOR` | `bgpNodeSelector` | All nodes |

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -132,7 +132,7 @@ config:
   # annotationPeerIPs: "metal.equinix.com/peer-ip"
   # annotationSrcIP: "metal.equinix.com/src-ip"
   # annotationBGPPass: "metal.equinix.com/bgp-pass"
-  # annotationNetworkIPv4Private: `metal.equinix.com/network/4/private`
+  # annotationNetworkIPv4Private: `metal.equinix.com/network-4-private`
   # eipTag: ""
   # apiServerPort: 6443
   # bgpNodeSelector: ""

--- a/metal/constants.go
+++ b/metal/constants.go
@@ -11,7 +11,7 @@ const (
 	DefaultAnnotationPeerIPs            = "metal.equinix.com/peer-ip"
 	DefaultAnnotationSrcIP              = "metal.equinix.com/src-ip"
 	DefaultAnnotationBGPPass            = "metal.equinix.com/bgp-pass"
-	DefaultAnnotationNetworkIPv4Private = "metal.equinix.com/network/4/private"
+	DefaultAnnotationNetworkIPv4Private = "metal.equinix.com/network-4-private"
 	DefaultLocalASN                     = 65000
 	DefaultPeerASN                      = 65530
 )


### PR DESCRIPTION
Kubernetes annotations only support a single `/` in the key. The code as it stands right now emits the following error:

```
 devices.go:307] instances.reconcileNodes(): failed to save updated node with annotations production-control-plane-1: Failed to patch node production-control-plane-1: Node "production-control-plane-1" is invalid: metadata.annotations: Invalid value: "metal.equinix.com/network/4/private": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
```

I've replaced the subsequent `/` with `-`, as dashes are used on other keys.

I suspect these annotations aren't being consumed by any other project yet, so I'd also offer an alternative:

```
network.metal.equinix.com/private-ipv4: ""`
network.metal.equinix.com/bgp-peer-asn: ""`

# etc
```

Thoughts? If we like that, I'll make the change. We could duplicate the BGP annotations until `kube-vip` is updated.

I couldn't find any other downstream code using them.