### PR TITLE
Add missing operator: Exists to Deployment

### DIFF
--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
           operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Exists
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/deploy/template/deployment.yaml
+++ b/deploy/template/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         # cloud controller manager should be able to run on masters
         - key: "node-role.kubernetes.io/master"
           effect: NoSchedule
+          operator: Exists
       containers:
       - image: equinix/cloud-provider-equinix-metal:RELEASE_TAG
         name: cloud-provider-equinix-metal


### PR DESCRIPTION
The default value for `operator` is `Equal`, but this doesn't provide
any value to check against, causing this to not be scheduled on control
plane nodes with the following taint:

```
  - effect: NoSchedule
    key: node-role.kubernetes.io/master
    value: "true"
```

Setting the operator to `Exists` will cause this to be scheduled.

cc @rawkode 