### PR TITLE
fix: dont start reconcilers when loadbalancer 'empty'

### DIFF
--- a/metal/loadbalancers.go
+++ b/metal/loadbalancers.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 
 	"github.com/equinix/cloud-provider-equinix-metal/metal/loadbalancers"
-	"github.com/equinix/cloud-provider-equinix-metal/metal/loadbalancers/empty"
 	"github.com/equinix/cloud-provider-equinix-metal/metal/loadbalancers/kubevip"
 	"github.com/equinix/cloud-provider-equinix-metal/metal/loadbalancers/metallb"
 	"github.com/packethost/packngo"
@@ -73,7 +72,9 @@ func (l *loadBalancers) init(k8sclient kubernetes.Interface) error {
 		impl = metallb.NewLB(k8sclient, config)
 	case "empty":
 		klog.Info("loadbalancer implementation enabled: empty, bgp only")
-		impl = empty.NewLB(k8sclient, config)
+		// Set to nil as we don't want nodeReconciler and serviceReconciler
+		// to start if the loadbalancer setting is "empty".
+		impl = nil
 	default:
 		klog.Info("loadbalancer implementation disabled")
 		impl = nil


### PR DESCRIPTION
Fixes: #200

This PR addresses the issue where even if the `loadbalancer:
empty://` is provided, CCM reconciles the Node and Service Objects
and tries to set the IP addresses to the services of type `LoadBalancer`

This is noticed when CCM is deployed with `loadBalancer: empty://` and
MetalLB is installed.

When an example service is installed of type LoadBalancer
What happens is that, MetalLB correctly assigns an IP from the address
pool but CCM updates the service.

This is because, we disable the reconcilers based on the condition if
the implementor is `nil`, which in its current state is never nil for
`empty` as the impl is set to &empty.LB{}.

Signed-off-by: Imran Pochi <imran@kinvolk.io>