### PR TITLE
switch annotation structure to support patterns and multiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,11 +203,11 @@ This section lists each configuration option, and whether it can be set by each 
 | Load balancer setting |   | `METAL_LOAD_BALANCER` | `loadbalancer` | none |
 | BGP ASN for cluster nodes when enabling BGP on the project |   | `METAL_LOCAL_ASN` | `localASN` | `65000` |
 | BGP passphrase to use when enabling BGP on the project |   | `METAL_BGP_PASS` | `bgpPass` | `""` |
-| Kubernetes annotation to set node's BGP ASN |   | `METAL_ANNOTATION_LOCAL_ASN` | `annotationLocalASN` | `"metal.equinix.com/node-asn"` |
-| Kubernetes annotation to set BGP peer's ASN |   | `METAL_ANNOTATION_PEER_ASNS` | `annotationPeerASNs` | `"metal.equinix.com/peer-asn"` |
-| Kubernetes annotation to set BGP peer's IPs |   | `METAL_ANNOTATION_PEER_IPS` | `annotationPeerIPs` | `"metal.equinix.com/peer-ip"` |
-| Kubernetes annotation to set source IP for BGP peering |   | `METAL_ANNOTATION_SRC_IP` | `annotationSrcIP` | `"metal.equinix.com/src-ip"` |
-| Kubernetes annotation to set BGP MD5 password, base64-encoded (see security warning below) |   | `METAL_ANNOTATION_BGP_PASS` | `annotationBGPPass` | `"metal.equinix.com/bgp-pass"` |
+| Kubernetes annotation to set node's BGP ASN, `{{n}}` replaced with ordinal index of peer |   | `METAL_ANNOTATION_LOCAL_ASN` | `annotationLocalASN` | `"metal.equinix.com/bgp-peers-{{n}}-node-asn"` |
+| Kubernetes annotation to set BGP peer's ASN, {{n}} replaced with ordinal index of peer |   | `METAL_ANNOTATION_PEER_ASN` | `annotationPeerASN` | `"metal.equinix.com/bgp-peers-{{n}}-peer-asn"` |
+| Kubernetes annotation to set BGP peer's IPs, {{n}} replaced with ordinal index of peer |   | `METAL_ANNOTATION_PEER_IP` | `annotationPeerIP` | `"metal.equinix.com/bgp-peers-{{n}}-peer-ip"` |
+| Kubernetes annotation to set source IP for BGP peering, {{n}} replaced with ordinal index of peer |   | `METAL_ANNOTATION_SRC_IP` | `annotationSrcIP` | `"metal.equinix.com/bgp-peers-{{n}}-src-ip"` |
+| Kubernetes annotation to set BGP MD5 password, base64-encoded (see security warning below) |   | `METAL_ANNOTATION_BGP_PASS` | `annotationBGPPass` | `"metal.equinix.com/bgp-peers-{{n}}-bgp-pass"` |
 | Kubernetes annotation to set the CIDR for the network range of the private address |  | `METAL_ANNOTATION_NETWORK_IPV4_PRIVATE` |  `annotationNetworkIPv4Private` | `metal.equinix.com/network-4-private` |
 | Tag for control plane Elastic IP |    | `METAL_EIP_TAG` | `eipTag` | No control plane Elastic IP |
 | Kubernetes API server port for Elastic IP |     | `METAL_API_SERVER_PORT` | `apiServerPort` | Same as `kube-apiserver` on control plane nodes, same as `0` |
@@ -527,15 +527,29 @@ Value for node selector should be a valid Kubernetes label selector (e.g. key1=v
 
 ## Node Annotations
 
-The Equinix Metal CCM sets Kubernetes annotations on each cluster node:
+The Equinix Metal CCM sets Kubernetes annotations on each cluster node.
 
-* Node, or local, ASN, default annotation `metal.equinix.com/node-asn`
-* Peer ASNs, comma-separated if multiple, default annotation `metal.equinix.com/peer-asns`
-* Peer IPs, comma-separated if multiple, default annotation `metal.equinix.com/peer-ips`
-* Source IP to use when communicating with upstream peers, default annotation `metal.equinix.com/src-ip`
-* CIDR of the private network range in the project which this node is part of, default annotation `metal.equinix.com/network-ipv4/private`
+* Node, or local, ASN, default annotation `metal.equinix.com/bgp-peers-{{n}}-node-asn`
+* Peer ASN, default annotation `metal.equinix.com/bgp-peers-{{n}}-peer-asn`
+* Peer IP, default annotation `metal.equinix.com/bgp-peers-{{n}}-peer-ip`
+* Source IP to use when communicating with peer, default annotation `metal.equinix.com/bgp-peers-{{n}}-src-ip`
+* BGP password for peer, default annotation `metal.equinix.com/bgp-peers-{{n}}-bgp-pass`
+* CIDR of the private network range in the project which this node is part of, default annotation `metal.equinix.com/network-4-private`
 
 These annotation names can be overridden, if you so choose, using the options in [Configuration][Configuration].
+
+Note that the annotations for BGP peering are a _pattern_. There is one annotation per data point per peer,
+following the pattern `metal.equinix.com/bgp-peers-{{n}}-<info>`, where:
+
+* `{{n}}` is the number of the peer, **always** starting with `0`
+* `<info>` is the relevant information, such as `node-asn` or `peer-ip`
+
+For example:
+
+* `metal.equinix.com/bgp-peers-0-peer-asn` - ASN of peer 0
+* `metal.equinix.com/bgp-peers-1-peer-asn` - ASN of peer 1
+* `metal.equinix.com/bgp-peers-0-peer-ip` - IP of peer 0
+* `metal.equinix.com/bgp-peers-1-peer-ip` - IP of peer 1
 
 ## Elastic IP Configuration
 

--- a/main.go
+++ b/main.go
@@ -30,8 +30,8 @@ const (
 	envVarLocalASN                     = "METAL_LOCAL_ASN"
 	envVarBGPPass                      = "METAL_BGP_PASS"
 	envVarAnnotationLocalASN           = "METAL_ANNOTATION_LOCAL_ASN"
-	envVarAnnotationPeerASNs           = "METAL_ANNOTATION_PEER_ASNS"
-	envVarAnnotationPeerIPs            = "METAL_ANNOTATION_PEER_IPS"
+	envVarAnnotationPeerASN            = "METAL_ANNOTATION_PEER_ASN"
+	envVarAnnotationPeerIP             = "METAL_ANNOTATION_PEER_IP"
 	envVarAnnotationSrcIP              = "METAL_ANNOTATION_SRC_IP"
 	envVarAnnotationBGPPass            = "METAL_ANNOTATION_BGP_PASS"
 	envVarAnnotationNetworkIPv4Private = "METAL_ANNOTATION_NETWORK_IPV4_PRIVATE"
@@ -170,15 +170,15 @@ func getMetalConfig(providerConfig string) (metal.Config, error) {
 	if annotationLocalASN != "" {
 		config.AnnotationLocalASN = annotationLocalASN
 	}
-	config.AnnotationPeerASNs = metal.DefaultAnnotationPeerASNs
-	annotationPeerASNs := os.Getenv(envVarAnnotationPeerASNs)
-	if annotationPeerASNs != "" {
-		config.AnnotationPeerASNs = annotationPeerASNs
+	config.AnnotationPeerASN = metal.DefaultAnnotationPeerASN
+	annotationPeerASN := os.Getenv(envVarAnnotationPeerASN)
+	if annotationPeerASN != "" {
+		config.AnnotationPeerASN = annotationPeerASN
 	}
-	config.AnnotationPeerIPs = metal.DefaultAnnotationPeerIPs
-	annotationPeerIPs := os.Getenv(envVarAnnotationPeerIPs)
-	if annotationPeerIPs != "" {
-		config.AnnotationPeerIPs = annotationPeerIPs
+	config.AnnotationPeerIP = metal.DefaultAnnotationPeerIP
+	annotationPeerIP := os.Getenv(envVarAnnotationPeerIP)
+	if annotationPeerIP != "" {
+		config.AnnotationPeerIP = annotationPeerIP
 	}
 	config.AnnotationSrcIP = metal.DefaultAnnotationSrcIP
 	annotationSrcIP := os.Getenv(envVarAnnotationSrcIP)

--- a/metal/cloud.go
+++ b/metal/cloud.go
@@ -73,7 +73,7 @@ func newCloud(metalConfig Config, client *packngo.Client) (cloudprovider.Interfa
 		instances:                   i,
 		zones:                       newZones(client, metalConfig.ProjectID),
 		loadBalancer:                newLoadBalancers(client, metalConfig.ProjectID, metalConfig.Facility, metalConfig.LoadBalancerSetting),
-		bgp:                         newBGP(client, metalConfig.ProjectID, metalConfig.LocalASN, metalConfig.BGPPass, metalConfig.AnnotationLocalASN, metalConfig.AnnotationPeerASNs, metalConfig.AnnotationPeerIPs, metalConfig.AnnotationSrcIP, metalConfig.AnnotationBGPPass, metalConfig.BGPNodeSelector),
+		bgp:                         newBGP(client, metalConfig.ProjectID, metalConfig.LocalASN, metalConfig.BGPPass, metalConfig.AnnotationLocalASN, metalConfig.AnnotationPeerASN, metalConfig.AnnotationPeerIP, metalConfig.AnnotationSrcIP, metalConfig.AnnotationBGPPass, metalConfig.BGPNodeSelector),
 		controlPlaneEndpointManager: newControlPlaneEndpointManager(metalConfig.EIPTag, metalConfig.ProjectID, client.DeviceIPs, client.ProjectIPs, i, metalConfig.APIServerPort),
 	}, nil
 }

--- a/metal/config.go
+++ b/metal/config.go
@@ -12,8 +12,8 @@ type Config struct {
 	LocalASN                     int     `json:"localASN,omitempty"`
 	BGPPass                      string  `json:"bgpPass,omitempty"`
 	AnnotationLocalASN           string  `json:"annotationLocalASN,omitEmpty"`
-	AnnotationPeerASNs           string  `json:"annotationPeerASNs,omitEmpty"`
-	AnnotationPeerIPs            string  `json:"annotationPeerIPs,omitEmpty"`
+	AnnotationPeerASN            string  `json:"annotationPeerASN,omitEmpty"`
+	AnnotationPeerIP             string  `json:"annotationPeerIP,omitEmpty"`
 	AnnotationSrcIP              string  `json:"annotationSrcIP,omitEmpty"`
 	AnnotationBGPPass            string  `json:"annotationBGPPass,omitEmpty"`
 	AnnotationNetworkIPv4Private string  `json:"annotationNetworkIPv4Private,omitEmpty"`

--- a/metal/constants.go
+++ b/metal/constants.go
@@ -6,11 +6,11 @@ const (
 	emIdentifier                        = "cloud-provider-equinix-metal-auto"
 	emTag                               = "usage=" + emIdentifier
 	ccmIPDescription                    = "Equinix Metal Kubernetes CCM auto-generated for Load Balancer"
-	DefaultAnnotationNodeASN            = "metal.equinix.com/node-asn"
-	DefaultAnnotationPeerASNs           = "metal.equinix.com/peer-asn"
-	DefaultAnnotationPeerIPs            = "metal.equinix.com/peer-ip"
-	DefaultAnnotationSrcIP              = "metal.equinix.com/src-ip"
-	DefaultAnnotationBGPPass            = "metal.equinix.com/bgp-pass"
+	DefaultAnnotationNodeASN            = "metal.equinix.com/bgp-peers-{{n}}-node-asn"
+	DefaultAnnotationPeerASN            = "metal.equinix.com/bgp-peers-{{n}}-peer-asn"
+	DefaultAnnotationPeerIP             = "metal.equinix.com/bgp-peers-{{n}}-peer-ip"
+	DefaultAnnotationSrcIP              = "metal.equinix.com/bgp-peers-{{n}}-src-ip"
+	DefaultAnnotationBGPPass            = "metal.equinix.com/bgp-peers-{{n}}-bgp-pass"
 	DefaultAnnotationNetworkIPv4Private = "metal.equinix.com/network-4-private"
 	DefaultLocalASN                     = 65000
 	DefaultPeerASN                      = 65530


### PR DESCRIPTION
Fixes #199 

**This is a breaking change**

It is breaking insofar as:

* the names of the 2 of the env vars for annotations are changed (they are singular. not plural)
* the env vars for BGP peer annotations are now _patterns_

I had thought of keeping at least the names unchanged, but once we are changing this, might as well get it right, rather than deal with the legacy.

This requires more extensive integration testing against real k8s clusters running on real EQXM. I want to get feedback from some people - especially @thebsdbox @johananl @ipochi - before going through the effort.