### PR TITLE
wrong use of variadic

### DIFF
--- a/metal/config.go
+++ b/metal/config.go
@@ -36,7 +36,7 @@ func (c Config) Strings() []string {
 	if c.LoadBalancerSetting == "" {
 		ret = append(ret, "loadbalancer config: disabled")
 	} else {
-		ret = append(ret, "load balancer config: ''%s", c.LoadBalancerSetting)
+		ret = append(ret, fmt.Sprintf("load balancer config: ''%s", c.LoadBalancerSetting))
 	}
 	ret = append(ret, fmt.Sprintf("facility: '%s'", c.Facility))
 	ret = append(ret, fmt.Sprintf("local ASN: '%d'", c.LocalASN))


### PR DESCRIPTION
minute issue, but `%!s(MISSING)` is always printed here.
```
load balancer config: ''%!s(MISSING)
<whatever is configured>
```