### PR TITLE
Add explicit metro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ This section lists each configuration option, and whether it can be set by each 
 | Path to config secret |    |    | `provider-config` | error |
 | API Key |    | `METAL_API_KEY` | `apiKey` | error |
 | Project ID |    | `METAL_PROJECT_ID` | `projectID` | error |
-| Facility |    | `METAL_FACILITY_NAME` | `facility` | read metadata on host on which CCM is running, else error |
+| Metro |    | `METAL_METRO_NAME` | `metro` | read metadata on host on which CCM is running, else error |
+| Facility |    | `METAL_FACILITY_NAME` | `facility` | if metro is set, leave blank, else read metadata on host on which CCM is running, else error |
 | Base URL to Equinix API |    |    | `base-url` | Official Equinix Metal API |
 | Load balancer setting |   | `METAL_LOAD_BALANCER` | `loadbalancer` | none |
 | BGP ASN for cluster nodes when enabling BGP on the project |   | `METAL_LOCAL_ASN` | `localASN` | `65000` |
@@ -604,14 +605,14 @@ You can run the CCM locally on your laptop or VM, i.e. not in the cluster. This 
 1. Build it for your local platform `make build`
 1. Set the environment variable `CCM_SECRET` to a file with the secret contents as a json, i.e. the content of the secret's `stringData`, e.g. `CCM_SECRET=ccm-secret.yaml`
 1. Set the environment variable `KUBECONFIG` to a kubeconfig file with sufficient access to the cluster, e.g. `KUBECONFIG=mykubeconfig`
-1. Set the environment variable `METAL_FACILITY_NAME` to the correct facility where the cluster is running, e.g. `METAL_FACILITY_NAME=ewr1`
+1. Set the environment variable `METAL_METRO_NAME` to the correct metro where the cluster is running, e.g. `METAL_METRO_NAME=ny` _OR_ set the environment variable `METAL_FACILITY_NAME` to the correct facility where the cluster is running, e.g. `METAL_FACILITY_NAME=ewr1`
 1. If you want to run the loadbalancer, and it is not yet deployed, run `kubectl apply -f deploy/loadbalancer.yaml`
 1. Enable the loadbalancer by setting the environment variable `METAL_LOAD_BALANCER=metallb://`
 1. If you want to use a managed Elastic IP for the control plane, create one using the Equinix Metal API or Web UI, tag it uniquely, and set the environment variable `METAL_EIP_TAG=<tag>`
 1. Run the command, e.g.:
 
 ```
-METAL_FACILITY_NAME=${METAL_FACILITY_NAME} METAL_LOAD_BALANCER=metallb:// dist/bin/cloud-provider-equinix-metal-darwin-amd64 --cloud-provider=equinixmetal --leader-elect=false --authentication-skip-lookup=true --provider-config=$CCM_SECRET --kubeconfig=$KUBECONFIG
+METAL_METRO_NAME=${METAL_METRO_NAME} METAL_LOAD_BALANCER=metallb:// dist/bin/cloud-provider-equinix-metal-darwin-amd64 --cloud-provider=equinixmetal --leader-elect=false --authentication-skip-lookup=true --provider-config=$CCM_SECRET --kubeconfig=$KUBECONFIG
 ```
 
 For lots of extra debugging, add `--v=2` or even higher levels, e.g. `--v=5`.

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -122,6 +122,7 @@ configSecret:
 config:
   apiKey: ""
   projectID: ""
+  # metro: metro
   # facility: facility
   # base-url: ""
   # loadbalancer: ""

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/equinix/cloud-provider-equinix-metal
 go 1.15
 
 require (
+	github.com/google/uuid v1.1.1 // indirect
 	github.com/hashicorp/go-hclog v0.12.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/packethost/packet-api-server v0.0.0-20200706140707-f0f79ef89944
-	github.com/packethost/packngo v0.17.0
+	github.com/packethost/packngo v0.19.2-0.20211119121357-05157869e685
 	github.com/pallinder/go-randomdata v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -447,6 +449,8 @@ github.com/packethost/packet-api-server v0.0.0-20200706140707-f0f79ef89944/go.mo
 github.com/packethost/packngo v0.2.1-0.20200629161839-1810e48469b4/go.mod h1:erURcsqYzwc9wSb04TX4so+s6F3uZtbXUil0W1LCGHA=
 github.com/packethost/packngo v0.17.0 h1:fGPlj9NDt6ejOrAMfUgx955oCaR1QBKA9pec14m0L38=
 github.com/packethost/packngo v0.17.0/go.mod h1:YrtUNN9IRjjqN6zK+cy2IYoi3EjHfoWTWxJkI1I1Vk0=
+github.com/packethost/packngo v0.19.2-0.20211119121357-05157869e685 h1:xBXxgQ5PeczC9gqv3XKK3/Fo6h9L+NGNb89mEpbbrFI=
+github.com/packethost/packngo v0.19.2-0.20211119121357-05157869e685/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/pallinder/go-randomdata v1.2.0 h1:EJPxw+sgM1mbMW8RBu5zkG4FbloJpDOCCqPccdWto8A=
 github.com/pallinder/go-randomdata v1.2.0/go.mod h1:p8CasZQiWDLuaKy5ihVvdshqc7LlL6ovmRxAuNXgi3U=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ const (
 	apiKeyName                         = "METAL_API_KEY"
 	projectIDName                      = "METAL_PROJECT_ID"
 	facilityName                       = "METAL_FACILITY_NAME"
+	metroName                          = "METAL_METRO_NAME"
 	loadBalancerSettingName            = "METAL_LOAD_BALANCER"
 	envVarLocalASN                     = "METAL_LOCAL_ASN"
 	envVarBGPPass                      = "METAL_BGP_PASS"
@@ -125,6 +126,10 @@ func getMetalConfig(providerConfig string) (metal.Config, error) {
 	if facility == "" {
 		facility = rawConfig.Facility
 	}
+	metro := os.Getenv(metroName)
+	if metro == "" {
+		metro = rawConfig.Metro
+	}
 
 	if apiToken == "" {
 		return config, fmt.Errorf("environment variable %q is required", apiKeyName)
@@ -135,14 +140,15 @@ func getMetalConfig(providerConfig string) (metal.Config, error) {
 	}
 
 	// if facility was not defined, retrieve it from our metadata
-	if facility == "" {
+	if facility == "" && metro == "" {
 		metadata, err := metal.GetAndParseMetadata("")
 		if err != nil {
-			return config, fmt.Errorf("facility not set in environment variable %q or config file, and error reading metadata: %v", facilityName, err)
+			return config, fmt.Errorf("metro and facility not set in environment variables %q and %q or config file, and error reading metadata: %v", metroName, facilityName, err)
 		}
-		facility = metadata.Facility
+		metro = metadata.Metro
 	}
 	config.Facility = facility
+	config.Metro = metro
 
 	// get the local ASN
 	localASN := os.Getenv(envVarLocalASN)

--- a/metal/cloud.go
+++ b/metal/cloud.go
@@ -59,6 +59,7 @@ type cloud struct {
 	instances                   cloudInstances
 	zones                       cloudZones
 	loadBalancer                cloudLoadBalancers
+	metro                       string
 	facility                    string
 	controlPlaneEndpointManager *controlPlaneEndpointManager
 	// holds our bgp service handler
@@ -69,10 +70,11 @@ func newCloud(metalConfig Config, client *packngo.Client) (cloudprovider.Interfa
 	i := newInstances(client, metalConfig.ProjectID, metalConfig.AnnotationNetworkIPv4Private)
 	return &cloud{
 		client:                      client,
+		metro:                       metalConfig.Metro,
 		facility:                    metalConfig.Facility,
 		instances:                   i,
 		zones:                       newZones(client, metalConfig.ProjectID),
-		loadBalancer:                newLoadBalancers(client, metalConfig.ProjectID, metalConfig.Facility, metalConfig.LoadBalancerSetting),
+		loadBalancer:                newLoadBalancers(client, metalConfig.ProjectID, metalConfig.Metro, metalConfig.Facility, metalConfig.LoadBalancerSetting),
 		bgp:                         newBGP(client, metalConfig.ProjectID, metalConfig.LocalASN, metalConfig.BGPPass, metalConfig.AnnotationLocalASN, metalConfig.AnnotationPeerASN, metalConfig.AnnotationPeerIP, metalConfig.AnnotationSrcIP, metalConfig.AnnotationBGPPass, metalConfig.BGPNodeSelector),
 		controlPlaneEndpointManager: newControlPlaneEndpointManager(metalConfig.EIPTag, metalConfig.ProjectID, client.DeviceIPs, client.ProjectIPs, i, metalConfig.APIServerPort),
 	}, nil

--- a/metal/cloud_test.go
+++ b/metal/cloud_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/google/uuid"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	emServer "github.com/packethost/packet-api-server/pkg/server"
 	"github.com/packethost/packet-api-server/pkg/store"
@@ -14,7 +15,6 @@ import (
 )
 
 const (
-	projectID       = "abcdef-123456"
 	token           = "12345678"
 	nodeName        = "ccm-test"
 	validRegionCode = "ewr1"
@@ -61,7 +61,7 @@ func testGetValidCloud(t *testing.T) (*cloud, *store.Memory) {
 
 	// now just need to create a client
 	config := Config{
-		ProjectID: projectID,
+		ProjectID: uuid.New().String(),
 	}
 	c, _ := newCloud(config, client)
 	validCloud = c.(*cloud)

--- a/metal/common_test.go
+++ b/metal/common_test.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"math/rand"
 
+	"github.com/google/uuid"
 	"github.com/packethost/packet-api-server/pkg/store"
 	"github.com/packethost/packngo"
 	"github.com/packethost/packngo/metadata"
 	randomdata "github.com/pallinder/go-randomdata"
 )
+
+var randomID = uuid.New().String()
 
 // find an ewr1 region or create it
 func testGetOrCreateValidRegion(name, code string, backend store.DataStore) (*packngo.Facility, error) {

--- a/metal/config.go
+++ b/metal/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	ProjectID                    string  `json:"projectId"`
 	BaseURL                      *string `json:"base-url,omitempty"`
 	LoadBalancerSetting          string  `json:"loadbalancer"`
+	Metro                        string  `json:"metro,omitempty"`
 	Facility                     string  `json:"facility,omitempty"`
 	LocalASN                     int     `json:"localASN,omitempty"`
 	BGPPass                      string  `json:"bgpPass,omitempty"`
@@ -38,6 +39,7 @@ func (c Config) Strings() []string {
 	} else {
 		ret = append(ret, fmt.Sprintf("load balancer config: ''%s", c.LoadBalancerSetting))
 	}
+	ret = append(ret, fmt.Sprintf("metro: '%s'", c.Metro))
 	ret = append(ret, fmt.Sprintf("facility: '%s'", c.Facility))
 	ret = append(ret, fmt.Sprintf("local ASN: '%d'", c.LocalASN))
 	ret = append(ret, fmt.Sprintf("Elastic IP Tag: '%s'", c.EIPTag))

--- a/metal/devices_test.go
+++ b/metal/devices_test.go
@@ -5,10 +5,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/packethost/packngo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+)
+
+var (
+	projectID = uuid.New().String()
 )
 
 func TestNodeAddresses(t *testing.T) {
@@ -86,13 +91,13 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 		addresses []v1.NodeAddress
 		err       error
 	}{
-		{"", nil, fmt.Errorf("providerID cannot be empty")},                                           // empty ID
-		{"foo-bar-abcdefg", nil, fmt.Errorf("instance not found")},                                    // invalid format
-		{"aws://abcdef5667", nil, fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetal
-		{"equinixmetal://acbdef-56788", nil, fmt.Errorf("instance not found")},                        // unknown ID
-		{fmt.Sprintf("equinixmetal://%s", dev.ID), validAddresses, nil},                               // valid
-		{fmt.Sprintf("packet://%s", dev.ID), validAddresses, nil},                                     // valid
-		{dev.ID, validAddresses, nil},                                                                 // valid
+		{"", nil, fmt.Errorf("providerID cannot be empty")},                                            // empty ID
+		{randomID, nil, fmt.Errorf("instance not found")},                                              // invalid format
+		{"aws://" + randomID, nil, fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetal
+		{"equinixmetal://" + randomID, nil, fmt.Errorf("instance not found")},                          // unknown ID
+		{fmt.Sprintf("equinixmetal://%s", dev.ID), validAddresses, nil},                                // valid
+		{fmt.Sprintf("packet://%s", dev.ID), validAddresses, nil},                                      // valid
+		{dev.ID, validAddresses, nil},                                                                  // valid
 	}
 
 	for i, tt := range tests {
@@ -177,12 +182,12 @@ func TestInstanceTypeByProviderID(t *testing.T) {
 		plan string
 		err  error
 	}{
-		{"", "", fmt.Errorf("providerID cannot be empty")},                                           // empty name
-		{"foo-bar-abcdefg", "", fmt.Errorf("instance not found")},                                    // invalid format
-		{"aws://abcdef5667", "", fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetalk
-		{"equinixmetal://acbdef-56788", "", fmt.Errorf("instance not found")},                        // unknown ID
-		{fmt.Sprintf("equinixmetal://%s", dev.ID), dev.Plan.Name, nil},                               // valid
-		{fmt.Sprintf("packet://%s", dev.ID), dev.Plan.Name, nil},                                     // valid
+		{"", "", fmt.Errorf("providerID cannot be empty")},                                            // empty name
+		{randomID, "", fmt.Errorf("instance not found")},                                              // invalid format
+		{"aws://" + randomID, "", fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetalk
+		{"equinixmetal://" + randomID, "", fmt.Errorf("instance not found")},                          // unknown ID
+		{fmt.Sprintf("equinixmetal://%s", dev.ID), dev.Plan.Name, nil},                                // valid
+		{fmt.Sprintf("packet://%s", dev.ID), dev.Plan.Name, nil},                                      // valid
 	}
 
 	for i, tt := range tests {
@@ -235,12 +240,12 @@ func TestInstanceExistsByProviderID(t *testing.T) {
 		exists bool
 		err    error
 	}{
-		{"", false, fmt.Errorf("providerID cannot be empty")},                                           // empty name
-		{"foo-bar-abcdefg", false, nil},                                                                 // invalid format
-		{"aws://abcdef5667", false, fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetal
-		{"equinixmetal://acbdef-56788", false, nil},                                                     // unknown ID
-		{fmt.Sprintf("equinixmetal://%s", dev.ID), true, nil},                                           // valid
-		{fmt.Sprintf("packet://%s", dev.ID), true, nil},                                                 // valid
+		{"", false, fmt.Errorf("providerID cannot be empty")}, // empty name
+		{randomID, false, nil},                                // invalid format
+		{"aws://" + randomID, false, fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetal
+		{"equinixmetal://" + randomID, false, nil},                                                       // unknown ID
+		{fmt.Sprintf("equinixmetal://%s", dev.ID), true, nil},                                            // valid
+		{fmt.Sprintf("packet://%s", dev.ID), true, nil},                                                  // valid
 		{dev.ID, true, nil}, // valid
 	}
 
@@ -274,16 +279,16 @@ func TestInstanceShutdownByProviderID(t *testing.T) {
 		down bool
 		err  error
 	}{
-		{"", false, fmt.Errorf("providerID cannot be empty")},                                           // empty name
-		{"foo-bar-abcdefg", false, fmt.Errorf("instance not found")},                                    // invalid format
-		{"aws://abcdef5667", false, fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetal
-		{"equinixmetal://acbdef-56788", false, fmt.Errorf("instance not found")},                        // unknown ID
-		{fmt.Sprintf("equinixmetal://%s", devActive.ID), false, nil},                                    // valid
-		{fmt.Sprintf("packet://%s", devActive.ID), false, nil},                                          // valid
-		{devActive.ID, false, nil},                                                                      // valid
-		{fmt.Sprintf("equinixmetal://%s", devInactive.ID), true, nil},                                   // valid
-		{fmt.Sprintf("packet://%s", devInactive.ID), true, nil},                                         // valid
-		{devInactive.ID, true, nil},                                                                     // valid
+		{"", false, fmt.Errorf("providerID cannot be empty")},                                            // empty name
+		{randomID, false, fmt.Errorf("instance not found")},                                              // invalid format
+		{"aws://" + randomID, false, fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetal
+		{"equinixmetal://" + randomID, false, fmt.Errorf("instance not found")},                          // unknown ID
+		{fmt.Sprintf("equinixmetal://%s", devActive.ID), false, nil},                                     // valid
+		{fmt.Sprintf("packet://%s", devActive.ID), false, nil},                                           // valid
+		{devActive.ID, false, nil},                                                                       // valid
+		{fmt.Sprintf("equinixmetal://%s", devInactive.ID), true, nil},                                    // valid
+		{fmt.Sprintf("packet://%s", devInactive.ID), true, nil},                                          // valid
+		{devInactive.ID, true, nil},                                                                      // valid
 	}
 
 	for i, tt := range tests {

--- a/metal/facilities_test.go
+++ b/metal/facilities_test.go
@@ -38,11 +38,11 @@ func TestGetZoneByProviderID(t *testing.T) {
 		region     string
 		err        error
 	}{
-		{"", "", fmt.Errorf("providerID cannot be empty")},                                           // empty ID
-		{"foo-bar-abcdefg", "", fmt.Errorf("instance not found")},                                    // invalid format
-		{"aws://abcdef5667", "", fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetal
-		{"equinixmetal://acbdef-56788", "", fmt.Errorf("instance not found")},                        // unknown ID
-		{fmt.Sprintf("equinixmetal://%s", dev.ID), validRegionCode, nil},                             // valid
+		{"", "", fmt.Errorf("providerID cannot be empty")},                                            // empty ID
+		{randomID, "", fmt.Errorf("instance not found")},                                              // invalid format
+		{"aws://" + randomID, "", fmt.Errorf("provider name from providerID should be equinixmetal")}, // not equinixmetal
+		{"equinixmetal://" + randomID, "", fmt.Errorf("instance not found")},                          // unknown ID
+		{fmt.Sprintf("equinixmetal://%s", dev.ID), validRegionCode, nil},                              // valid
 	}
 
 	zones, _ := vc.Zones()


### PR DESCRIPTION
Explicitly uses an environment variable or config to set the metro, falling back to metadata. If both are specified, both are sent in the EIP creation request.