### PR TITLE
Clean logging

### DIFF
--- a/metal/bgp.go
+++ b/metal/bgp.go
@@ -106,7 +106,7 @@ func (b *bgp) reconcileNodes(ctx context.Context, nodes []*v1.Node, mode UpdateM
 			klog.V(2).Infof("bgp.reconcileNodes(): enabling BGP on node %s", node.Name)
 			// ensure BGP is enabled for the node
 			if err := ensureNodeBGPEnabled(id, b.client); err != nil {
-				klog.Errorf("could not ensure BGP enabled for node %s: %v", node.Name, err)
+				return fmt.Errorf("could not ensure BGP enabled for node %s: %v", node.Name, err)
 			}
 			klog.V(2).Infof("bgp.reconcileNodes(): bgp enabled on node %s", node.Name)
 

--- a/metal/cloud.go
+++ b/metal/cloud.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/packethost/packngo"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -119,17 +117,10 @@ func (c *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 	clientset := clientBuilder.ClientOrDie("cloud-provider-equinix-metal-shared-informers")
 	sharedInformer := informers.NewSharedInformerFactory(clientset, 0)
 	// if we have services that want to reconcile, we will start node loop
-	nodeReconcilers := []nodeReconciler{}
-	serviceReconcilers := []serviceReconciler{}
-	for _, elm := range c.services() {
+	services := c.services()
+	for _, elm := range services {
 		if err := elm.init(clientset); err != nil {
 			klog.Fatalf("could not initialize %s: %v", elm.name(), err)
-		}
-		if n := elm.nodeReconciler(); n != nil {
-			nodeReconcilers = append(nodeReconcilers, n)
-		}
-		if s := elm.serviceReconciler(); s != nil {
-			serviceReconcilers = append(serviceReconcilers, s)
 		}
 	}
 
@@ -139,14 +130,26 @@ func (c *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 		cancel()
 	}()
 
-	if err := startNodesWatcher(ctx, sharedInformer, nodeReconcilers); err != nil {
-		klog.Errorf("nodes watcher initialization failed: %v", err)
+	var watchers []cache.SharedIndexInformer
+	nodesWatcher, err := createNodesWatcher(ctx, sharedInformer, services)
+	if err != nil {
+		klog.Fatalf("nodes watcher initialization failed: %v", err)
 	}
-	if err := startServicesWatcher(ctx, sharedInformer, serviceReconcilers); err != nil {
-		klog.Errorf("services watcher initialization failed: %v", err)
+	if nodesWatcher != nil {
+		watchers = append(watchers, nodesWatcher)
 	}
-	go timerLoop(ctx, sharedInformer, nodeReconcilers, serviceReconcilers)
-	klog.V(5).Info("Initialize complete")
+	servicesWatcher, err := createServicesWatcher(ctx, sharedInformer, services)
+	if err != nil {
+		klog.Fatalf("services watcher initialization failed: %v", err)
+	}
+	if servicesWatcher != nil {
+		watchers = append(watchers, servicesWatcher)
+	}
+	if err := startWatchers(ctx, watchers); err != nil {
+		klog.Fatalf("watchers initialization failed: %v", err)
+	}
+	go timerLoop(ctx, sharedInformer, services)
+	klog.Info("Initialize of cloud provider complete")
 }
 
 // LoadBalancer returns a balancer interface. Also returns true if the interface is supported, false otherwise.
@@ -196,146 +199,4 @@ func (c *cloud) ProviderName() string {
 func (c *cloud) HasClusterID() bool {
 	klog.V(5).Info("called HasClusterID")
 	return true
-}
-
-// startNodesWatcher start a goroutine that watches k8s for nodes and calls any handlers
-func startNodesWatcher(ctx context.Context, informer informers.SharedInformerFactory, handlers []nodeReconciler) error {
-	klog.V(5).Info("called startNodesWatcher")
-	if len(handlers) == 0 {
-		klog.V(5).Info("no node handlers to process")
-		return nil
-	}
-
-	klog.V(5).Info("startNodesWatcher(): creating nodesInformer")
-	nodesInformer := informer.Core().V1().Nodes().Informer()
-	klog.V(5).Info("startNodesWatcher(): adding event handlers")
-	nodesInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			n := obj.(*v1.Node)
-			for _, h := range handlers {
-				if err := h(ctx, []*v1.Node{n}, ModeAdd); err != nil {
-					klog.Errorf("failed to update and sync node for add %s for handler: %v", n.Name, err)
-				}
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			n := obj.(*v1.Node)
-			for _, h := range handlers {
-				if err := h(ctx, []*v1.Node{n}, ModeRemove); err != nil {
-					klog.Errorf("failed to update and sync node for remove %s for handler: %v", n.Name, err)
-				}
-			}
-		},
-	})
-
-	// what this does:
-	// when you create an informer, you start it by calling informer.Run()
-	// however, it can take some time for the local state to sync up. If you use any methods before
-	// it is completely synced, especially get or list, you can end up missing data. In order to
-	// avoid the issue, you run it in the following order:
-	//
-	// 1. create your informer
-	// 2. informer.Run()
-	// 3. create a slice of sync functions []cache.InformerSynced. The function on each informer is informer.HasSynced
-	// 4. use the utility function cache.WaitForCacheSync(), passing it your sync function slice
-	// 5. when the utility function returns, the cache is synced and you are ready to use it
-	//
-	// for a good overview of controllers and their lifecycle, see https://engineering.bitnami.com/articles/a-deep-dive-into-kubernetes-controllers.html
-	klog.V(5).Info("startNodesWatcher(): nodesInformer.Run()")
-	go nodesInformer.Run(ctx.Done())
-	syncFuncs := []cache.InformerSynced{
-		nodesInformer.HasSynced,
-	}
-	klog.V(4).Infof("startNodesWatcher(): waiting for caches to sync")
-	if !cache.WaitForCacheSync(ctx.Done(), syncFuncs...) {
-		return fmt.Errorf("syncing caches failed")
-	}
-	klog.Info("nodes watcher started")
-	return nil
-}
-
-// startServicesWatcher start a goroutine that watches k8s for services and calls
-// any handlers
-func startServicesWatcher(ctx context.Context, informer informers.SharedInformerFactory, handlers []serviceReconciler) error {
-	klog.V(5).Info("called startServicesWatcher")
-	if len(handlers) == 0 {
-		klog.V(5).Info("no service handlers to process")
-		return nil
-	}
-
-	// register to capture all new services
-	servicesInformer := informer.Core().V1().Services().Informer()
-	servicesInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			svc := obj.(*v1.Service)
-			for _, h := range handlers {
-				if err := h(ctx, []*v1.Service{svc}, ModeAdd); err != nil {
-					klog.Errorf("failed to update and sync service for add %s/%s: %v", svc.Namespace, svc.Name, err)
-				}
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			svc := obj.(*v1.Service)
-			for _, h := range handlers {
-				if err := h(ctx, []*v1.Service{svc}, ModeRemove); err != nil {
-					klog.Errorf("failed to update and sync service for remove %s/%s: %v", svc.Namespace, svc.Name, err)
-				}
-			}
-		},
-	})
-	// what this does:
-	// when you create an informer, you start it by calling informer.Run()
-	// however, it can take some time for the local state to sync up. If you use any methods before
-	// it is completely synced, especially get or list, you can end up missing data. In order to
-	// avoid the issue, you run it in the following order:
-	//
-	// 1. create your informer
-	// 2. informer.Run()
-	// 3. create a slice of sync functions []cache.InformerSynced. The function on each informer is informer.HasSynced
-	// 4. use the utility function cache.WaitForCacheSync(), passing it your sync function slice
-	// 5. when the utility function returns, the cache is synced and you are ready to use it
-	//
-	// for a good overview of controllers and their lifecycle, see https://engineering.bitnami.com/articles/a-deep-dive-into-kubernetes-controllers.html
-	klog.V(5).Info("startServicesWatcher(): servicesInformer.Run()")
-	go servicesInformer.Run(ctx.Done())
-	syncFuncs := []cache.InformerSynced{
-		servicesInformer.HasSynced,
-	}
-	klog.V(4).Infof("startServicesWatcher(): waiting for caches to sync")
-	if !cache.WaitForCacheSync(ctx.Done(), syncFuncs...) {
-		return fmt.Errorf("syncing caches failed")
-	}
-	klog.Info("services watcher started")
-
-	return nil
-}
-
-func timerLoop(ctx context.Context, informer informers.SharedInformerFactory, nodesHandlers []nodeReconciler, servicesHandlers []serviceReconciler) {
-	servicesLister := informer.Core().V1().Services().Lister()
-	nodesLister := informer.Core().V1().Nodes().Lister()
-	for {
-		select {
-		case <-time.After(checkLoopTimerSeconds * time.Second):
-			servicesList, err := servicesLister.List(labels.Everything())
-			if err != nil {
-				klog.Errorf("timed reservations watcher: failed to list services: %v", err)
-			}
-			for _, h := range servicesHandlers {
-				if err := h(ctx, servicesList, ModeSync); err != nil {
-					klog.Errorf("failed to update and sync services: %v", err)
-				}
-			}
-			nodesList, err := nodesLister.List(labels.Everything())
-			if err != nil {
-				klog.Errorf("timed reservations watcher: failed to list nodes: %v", err)
-			}
-			for _, h := range nodesHandlers {
-				if err := h(ctx, nodesList, ModeSync); err != nil {
-					klog.Errorf("failed to update and sync nodes: %v", err)
-				}
-			}
-		case <-ctx.Done():
-			return
-		}
-	}
 }

--- a/metal/loadbalancers.go
+++ b/metal/loadbalancers.go
@@ -124,7 +124,8 @@ func (l *loadBalancers) serviceReconciler() serviceReconciler {
 	return l.reconcileServices
 }
 
-// reconcileNodes given a node, update the metallb load balancer by
+// reconcileNodes prepares and applies changes to the loadbalancer implementation
+// given a set of nodes and a mode of reconciliation (add, remove, or sync) 
 // by adding it to or removing it from any known loadbalancer implementation
 func (l *loadBalancers) reconcileNodes(ctx context.Context, nodes []*v1.Node, mode UpdateMode) error {
 	var (

--- a/metal/loadbalancers.go
+++ b/metal/loadbalancers.go
@@ -125,8 +125,7 @@ func (l *loadBalancers) serviceReconciler() serviceReconciler {
 }
 
 // reconcileNodes prepares and applies changes to the loadbalancer implementation
-// given a set of nodes and a mode of reconciliation (add, remove, or sync) 
-// by adding it to or removing it from any known loadbalancer implementation
+// given a set of nodes and a mode of reconciliation (add, remove, or sync)
 func (l *loadBalancers) reconcileNodes(ctx context.Context, nodes []*v1.Node, mode UpdateMode) error {
 	var (
 		peer *packngo.BGPNeighbor

--- a/metal/watchers.go
+++ b/metal/watchers.go
@@ -1,0 +1,143 @@
+package metal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// createNodesWatcher create a cache.SharedIndexInformation for node handlers
+func createNodesWatcher(ctx context.Context, informer informers.SharedInformerFactory, cloudServices []cloudService) (cache.SharedIndexInformer, error) {
+	klog.V(5).Info("called createNodesWatcher")
+
+	klog.V(5).Info("createNodesWatcher(): creating nodesInformer")
+	nodesInformer := informer.Core().V1().Nodes().Informer()
+	klog.V(5).Info("createNodesWatcher(): adding event handlers")
+	nodesInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			n := obj.(*v1.Node)
+			for _, csvc := range cloudServices {
+				if handler := csvc.nodeReconciler(); handler != nil {
+					if err := handler(ctx, []*v1.Node{n}, ModeAdd); err != nil {
+						klog.Errorf("%s failed to update and sync node for add %s for handler: %v", csvc.name(), n.Name, err)
+					}
+				}
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			n := obj.(*v1.Node)
+			for _, csvc := range cloudServices {
+				if handler := csvc.nodeReconciler(); handler != nil {
+					if err := handler(ctx, []*v1.Node{n}, ModeRemove); err != nil {
+						klog.Errorf("%s failed to update and sync node for remove %s for handler: %v", csvc.name(), n.Name, err)
+					}
+				}
+			}
+		},
+	})
+
+	return nodesInformer, nil
+}
+
+// createServicesWatcher create a cache.SharedIndexInformation for services handlers
+func createServicesWatcher(ctx context.Context, informer informers.SharedInformerFactory, cloudServices []cloudService) (cache.SharedIndexInformer, error) {
+	klog.V(5).Info("called createServicesWatcher")
+
+	// register to capture all new services
+	servicesInformer := informer.Core().V1().Services().Informer()
+	servicesInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			svc := obj.(*v1.Service)
+			for _, csvc := range cloudServices {
+				if handler := csvc.serviceReconciler(); handler != nil {
+					if err := handler(ctx, []*v1.Service{svc}, ModeAdd); err != nil {
+						klog.Errorf("%s failed to update and sync service for add %s/%s: %v", csvc.name(), svc.Namespace, svc.Name, err)
+					}
+				}
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			svc := obj.(*v1.Service)
+			for _, csvc := range cloudServices {
+				if handler := csvc.serviceReconciler(); svc != nil {
+					if err := handler(ctx, []*v1.Service{svc}, ModeRemove); err != nil {
+						klog.Errorf("%s failed to update and sync service for remove %s/%s: %v", csvc.name(), svc.Namespace, svc.Name, err)
+					}
+				}
+			}
+		},
+	})
+
+	return servicesInformer, nil
+}
+
+// startWatchers start the various informers in their own go routines, and wait for sync to be done
+func startWatchers(ctx context.Context, informers []cache.SharedIndexInformer) error {
+	klog.V(5).Info("startWatchers() started")
+	// what this does:
+	// when you create an informer, you start it by calling informer.Run()
+	// however, it can take some time for the local state to sync up. If you use any methods before
+	// it is completely synced, especially get or list, you can end up missing data. In order to
+	// avoid the issue, you run it in the following order:
+	//
+	// 1. create your informer
+	// 2. informer.Run()
+	// 3. create a slice of sync functions []cache.InformerSynced. The function on each informer is informer.HasSynced
+	// 4. use the utility function cache.WaitForCacheSync(), passing it your sync function slice
+	// 5. when the utility function returns, the cache is synced and you are ready to use it
+	//
+	// for a good overview of controllers and their lifecycle, see https://engineering.bitnami.com/articles/a-deep-dive-into-kubernetes-controllers.html
+	var syncFuncs []cache.InformerSynced
+	for _, informer := range informers {
+		go informer.Run(ctx.Done())
+		syncFuncs = append(syncFuncs, informer.HasSynced)
+	}
+	klog.V(4).Infof("startWatchers(): waiting for caches to sync")
+	if !cache.WaitForCacheSync(ctx.Done(), syncFuncs...) {
+		return fmt.Errorf("syncing caches failed")
+	}
+	klog.Info("all watchers started")
+	return nil
+}
+
+func timerLoop(ctx context.Context, informer informers.SharedInformerFactory, cloudServices []cloudService) {
+	klog.V(5).Infof("timerLoop(): starting loop")
+	servicesLister := informer.Core().V1().Services().Lister()
+	nodesLister := informer.Core().V1().Nodes().Lister()
+	for {
+		select {
+		case <-time.After(checkLoopTimerSeconds * time.Second):
+			// with each loop, get all of the services and nodes,
+			// then loop through each service and see if it provides a serviceReconciler
+			// and a nodeReconciler.
+			servicesList, err := servicesLister.List(labels.Everything())
+			if err != nil {
+				klog.Errorf("timer loop had error listing services, will try next loop: %v", err)
+			}
+			nodesList, err := nodesLister.List(labels.Everything())
+			if err != nil {
+				klog.Errorf("timer loop had error listing nodes, will try next loop: %v", err)
+			}
+			for _, svc := range cloudServices {
+				if handler := svc.serviceReconciler(); handler != nil {
+					if err := handler(ctx, servicesList, ModeSync); err != nil {
+						klog.Errorf("%s: error updating and syncing services, will try next loop: %v", svc.name(), err)
+					}
+				}
+				if handler := svc.nodeReconciler(); handler != nil {
+					if err := handler(ctx, nodesList, ModeSync); err != nil {
+						klog.Errorf("%s: error updating and syncing nodes, will try next loop: %v", svc.name(), err)
+					}
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}


### PR DESCRIPTION
This has two commits.

The first restructures some of the files and funcs without changing any functionality. It just reduces duplicate code, makes it easier to understand, separates some things into their own file, etc.

The second cleans up the logging:

* do not return an error for something that isn't actually an error. If it is informative, log a message (at various log levels), but return `nil`
* if we have a non-fatal error in a loop, log the message, save the affected resource in a slice, and complete the loop. Only at the end should we return the error.

I have wanted to do this for a long time.