### PR TITLE
report versions correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,20 @@ PACKAGE_NAME?=github.com/equinix/cloud-provider-equinix-metal
 GIT_VERSION?=$(shell git log -1 --format="%h")
 VERSION?=$(GIT_VERSION)
 RELEASE_TAG ?= $(shell git tag --points-at HEAD)
+MOST_RECENT_RELEASE_TAG ?= $(shell git describe --abbrev=0  2>/dev/null || true)
+ifeq (,$(MOST_RECENT_RELEASE_TAG))
+MOST_RECENT_RELEASE_TAG = v0.0.0
+endif
 ifneq (,$(RELEASE_TAG))
-VERSION := $(RELEASE_TAG)-$(VERSION)
+VERSION := $(RELEASE_TAG)
+else
+VERSION := $(MOST_RECENT_RELEASE_TAG)-$(VERSION)
 endif
 GO_FILES := $(shell find . -type f -not -path './vendor/*' -name '*.go')
 BUILD_TAG ?= latest
 TAGGED_IMAGE ?= $(BUILD_IMAGE):$(BUILD_TAG)
 TAGGED_ARCH_IMAGE ?= $(TAGGED_IMAGE)-$(ARCH)
-LDFLAGS ?= -ldflags '-extldflags "-static" -X "$(PACKAGE_NAME)/version.VERSION=$(VERSION)"'
+LDFLAGS ?= -ldflags '-extldflags "-static" -X "k8s.io/component-base/version.gitVersion=$(VERSION)"'
 
 # which arches can we support
 ARCHES=arm64 amd64

--- a/metal/cloud.go
+++ b/metal/cloud.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 )
 
@@ -96,7 +97,7 @@ func init() {
 
 		// set up our client and create the cloud interface
 		client := packngo.NewClientWithAuth("cloud-provider-equinix-metal", metalConfig.AuthToken, nil)
-		client.UserAgent = fmt.Sprintf("cloud-provider-equinix-metal/%s %s", VERSION, client.UserAgent)
+		client.UserAgent = fmt.Sprintf("cloud-provider-equinix-metal/%s %s", version.Get(), client.UserAgent)
 		cloud, err := newCloud(metalConfig, client)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create new cloud handler: %v", err)

--- a/metal/version.go
+++ b/metal/version.go
@@ -1,8 +1,0 @@
-// This file does not need to be updated. Release versions are set at build time (see LDFLAGS in the Makefile)
-
-package metal
-
-var (
-	// VERSION is reported in the API User-Agent
-	VERSION = "devel"
-)


### PR DESCRIPTION
Fixes #142 

Works with the Kubernetes standard versioning (without all of the branch complexity)