### PR TITLE
set programName rendered in `--version` output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GO_FILES := $(shell find . -type f -not -path './vendor/*' -name '*.go')
 BUILD_TAG ?= latest
 TAGGED_IMAGE ?= $(BUILD_IMAGE):$(BUILD_TAG)
 TAGGED_ARCH_IMAGE ?= $(TAGGED_IMAGE)-$(ARCH)
-LDFLAGS ?= -ldflags '-extldflags "-static" -X "k8s.io/component-base/version.gitVersion=$(VERSION)"'
+LDFLAGS ?= -ldflags '-extldflags "-static" -X "k8s.io/component-base/version.gitVersion=$(VERSION)" -X "k8s.io/component-base/version/verflag.programName=Cloud Provider Equinix Metal"'
 
 # which arches can we support
 ARCHES=arm64 amd64


### PR DESCRIPTION
We can use `-X "k8s.io/component-base/version/verflag.programName=Cloud Provider Equinix Metal"` to set a custom program name. This overrides the default of `Kubernetes`.

It makes more sense for `{ccm} --version` to say `Cloud Provider Equinix Metal v3.3.0` rather than `Kubernetes v3.3.0`.

This is a follow-up to the conversation in https://github.com/equinix/cloud-provider-equinix-metal/pull/221#discussion_r769741420

Related to https://github.com/equinix/cloud-provider-equinix-metal/issues/142