### PR TITLE
use standard API LoadBalancers

### DIFF
--- a/metal/cloud_test.go
+++ b/metal/cloud_test.go
@@ -74,8 +74,8 @@ func TestLoadBalancer(t *testing.T) {
 	vc, _ := testGetValidCloud(t)
 	response, supported := vc.LoadBalancer()
 	var (
-		expectedSupported = false
-		expectedResponse  cloudprovider.LoadBalancer // defaults to nil
+		expectedSupported = true
+		expectedResponse  = response
 	)
 	if supported != expectedSupported {
 		t.Errorf("supported returned %v instead of expected %v", supported, expectedSupported)

--- a/metal/loadbalancers/empty/empty.go
+++ b/metal/loadbalancers/empty/empty.go
@@ -15,29 +15,14 @@ func NewLB(k8sclient kubernetes.Interface, config string) *LB {
 	return &LB{}
 }
 
-func (l *LB) AddService(ctx context.Context, svc, ip string) error {
+func (l *LB) AddService(ctx context.Context, svc, ip string, nodes []loadbalancers.Node) error {
 	return nil
 }
 
-func (l *LB) RemoveService(ctx context.Context, ip string) error {
+func (l *LB) RemoveService(ctx context.Context, svc, ip string) error {
 	return nil
 }
 
-func (l *LB) SyncServices(ctx context.Context, ips map[string]bool) error {
-	return nil
-}
-
-// AddNode add a node with the provided name, srcIP, and bgp information
-func (l *LB) AddNode(ctx context.Context, nodeName string, localASN, peerASN int, password, srcIP string, peers ...string) error {
-	return nil
-}
-
-// RemoveNode remove a node with the provided name
-func (l *LB) RemoveNode(ctx context.Context, nodeName string) error {
-	return nil
-}
-
-// SyncNodes ensure that the list of nodes is only those with the matched names
-func (l *LB) SyncNodes(ctx context.Context, nodes map[string]loadbalancers.Node) error {
+func (l *LB) UpdateService(ctx context.Context, svc string, nodes []loadbalancers.Node) error {
 	return nil
 }

--- a/metal/loadbalancers/interface.go
+++ b/metal/loadbalancers/interface.go
@@ -5,16 +5,10 @@ import (
 )
 
 type LB interface {
-	// AddNode add a node with the provided name, srcIP, and bgp information
-	AddNode(ctx context.Context, nodeName string, localASN, peerASN int, pass string, srcIP string, peers ...string) error
-	// RemoveNode remove a node with the provided name
-	RemoveNode(ctx context.Context, nodeName string) error
-	// SyncNodes ensure that the list of nodes is only those with the matched names
-	SyncNodes(ctx context.Context, nodes map[string]Node) error
 	// AddService add a service with the provided name and IP
-	AddService(ctx context.Context, svc, ip string) error
+	AddService(ctx context.Context, svc, ip string, nodes []Node) error
 	// RemoveService remove service with the given IP
-	RemoveService(ctx context.Context, ip string) error
-	// SyncServices ensure that the list of services is only those with the matched IPs
-	SyncServices(ctx context.Context, ips map[string]bool) error
+	RemoveService(ctx context.Context, svc, ip string) error
+	// UpdateService ensure that the nodes handled by the service are correct
+	UpdateService(ctx context.Context, svc string, nodes []Node) error
 }

--- a/metal/loadbalancers/kubevip/kubevip.go
+++ b/metal/loadbalancers/kubevip/kubevip.go
@@ -15,29 +15,14 @@ func NewLB(k8sclient kubernetes.Interface, config string) *LB {
 	return &LB{}
 }
 
-func (l *LB) AddService(ctx context.Context, svc, ip string) error {
+func (l *LB) AddService(ctx context.Context, svc, ip string, nodes []loadbalancers.Node) error {
 	return nil
 }
 
-func (l *LB) RemoveService(ctx context.Context, ip string) error {
+func (l *LB) RemoveService(ctx context.Context, svc, ip string) error {
 	return nil
 }
 
-func (l *LB) SyncServices(ctx context.Context, ips map[string]bool) error {
-	return nil
-}
-
-// AddNode add a node with the provided name, srcIP, and bgp information
-func (l *LB) AddNode(ctx context.Context, nodeName string, localASN, peerASN int, password, srcIP string, peers ...string) error {
-	return nil
-}
-
-// RemoveNode remove a node with the provided name
-func (l *LB) RemoveNode(ctx context.Context, nodeName string) error {
-	return nil
-}
-
-// SyncNodes ensure that the list of nodes is only those with the matched names
-func (l *LB) SyncNodes(ctx context.Context, nodes map[string]loadbalancers.Node) error {
+func (l *LB) UpdateService(ctx context.Context, svc string, nodes []loadbalancers.Node) error {
 	return nil
 }

--- a/metal/loadbalancers/metallb/util_test.go
+++ b/metal/loadbalancers/metallb/util_test.go
@@ -1,6 +1,10 @@
 package metallb
 
-import "math/rand"
+import (
+	"math/rand"
+	"sort"
+	"strings"
+)
 
 func genRandomString(l int) string {
 	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -69,8 +73,8 @@ func genSelectorRequirements() SelectorRequirements {
 	}
 }
 
-func genPeer() Peer {
-	return Peer{
+func genPeer(svcs ...string) Peer {
+	p := Peer{
 		MyASN:    uint32(rand.Intn(75000)),
 		ASN:      uint32(rand.Intn(75000)),
 		Addr:     genRandomString(10),
@@ -83,4 +87,13 @@ func genPeer() Peer {
 			genNodeSelector(),
 		},
 	}
+	if len(svcs) > 0 {
+		sort.Strings(svcs)
+		p.NodeSelectors = append(p.NodeSelectors, NodeSelector{
+			MatchLabels: map[string]string{
+				serviceNameKey: strings.Join(svcs, ","),
+			},
+		})
+	}
+	return p
 }

--- a/metal/watchers.go
+++ b/metal/watchers.go
@@ -65,7 +65,7 @@ func createServicesWatcher(ctx context.Context, informer informers.SharedInforme
 		DeleteFunc: func(obj interface{}) {
 			svc := obj.(*v1.Service)
 			for _, csvc := range cloudServices {
-				if handler := csvc.serviceReconciler(); svc != nil {
+				if handler := csvc.serviceReconciler(); handler != nil {
 					if err := handler(ctx, []*v1.Service{svc}, ModeRemove); err != nil {
 						klog.Errorf("%s failed to update and sync service for remove %s/%s: %v", csvc.name(), svc.Namespace, svc.Name, err)
 					}


### PR DESCRIPTION
This is a deep change in how CCM operates.

## Design Change

### Existing

The CCM has listeners for changes to services and nodes, as well as a timer loop. Every time a node or service is added or removed, or a node is added or removed, it calls the `serviceReconciler` or `nodeReconciler` or each sub-service - bgp, loadbalancers, devices, facilities, control-plane-EIP. Some of these return `nil`, indicating "nothing to do".

The main ones that handle it are bgp and load balancer. 

* services: looks at the added service, filters for `type=LoadBalancer`, gets an EIP from EQXM if needed, and then calls the specific implementation of load balancer to add or remove it
* nodes: looks at the node, filters out for specific labels if provided, and then ensures bgp is enabled on the node, adds annotations, and tells the specific LB implementation about it

The problems with the existing design are as follows:

* does not follow the [official cloud provider Interface](https://pkg.go.dev/k8s.io/cloud-provider#Interface), which expects to manage a standard set of [LoadBalancer calls](https://pkg.go.dev/k8s.io/cloud-provider#LoadBalancer); this makes understanding what this does harder
* because of the previous one, we have to do a lot of handling of state, sync, etc. that shouldn't be the CCM's problem
* spreads the work to different areas
* is more complex to handle and reason about

### Proposed

Use the provided standard [LoadBalancer API](https://pkg.go.dev/k8s.io/cloud-provider#LoadBalancer).

In doing so, we eliminate almost all of the watcher and timer loop calls, save the ones to the control plane EIP, that will have to be figured out separately. 

This does, however, have a different mindset. In the ones we have done, nodes are added/removed and services added/removed, but no connection between them. In the official k8s mindset as it relates to LBs, nodes are simply endpoints for an LB. Thus, the idea of "add a node" makes no sense. Instead, it says, "add a Load Balancer and here are the nodes for it", "update a load balancer with these nodes", and "remove a load balancer and any of its attendant nodes".

To do this, we had to changes what we send to the specific LB implementation and how. It actually simplified the interface.

## Challenges

Most of these changes affect only the CCM itself or one specific LB implementation, i.e. metallb. Others (mainly kube-vip) do not rely on those and just use the annotations as they appear.

For metallb, we need some way of tracking which nodes are announcing for which services, i.e. which nodes (announced) "back" which LB (EIP). This is not inherent anywhere in the metallb config file. We cannot just store it in memory, as that is not persistent. The metallb config file has no comment or description fields, for either address pool or peer listing, so that doesn't help. 

I did something rather ugly by overloading the `NodeSelector.MatchLabel` to have one that indicates what service it is.

```yaml
peers:
- peer-address: 10.0.0.1
  peer-asn: 64501
  my-asn: 64500
  node-selectors:
  - match-labels:
      kubernetes.io/hostname: my-node
      nomatch.metal.equinix.com/service-name: serviceA
```

I will be the first to admit that is _ugly_, and wrong. But I couldn't come up with a cleaner way to start it. At least it should provoke the conversation.

The other downside is that we now need one peer entry for each service. Actually, we need 2, one for each upstream ToR router. If we have 20 services across 5 nodes, instead of 10 entries, we now need 200 (2 per service per node).

So I really don't want this to get merged in as is. But I would like some better ideas as to how to manage it.
