### PR TITLE
use external copy of DCO in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in improving this project! Before we get technical,
 make sure you have reviewed the [code of conduct](code-of-conduct.md),
-[Developer Certificate of Origin](DCO), and [OWNERS](OWNERS.md) files. Code will
+[Developer Certificate of Origin](https://developercertificate.org/), and [OWNERS](OWNERS.md) files. Code will
 be licensed according to [LICENSE](LICENSE).
 
 ## Pull Requests


### PR DESCRIPTION
Fixes #218 

The DCO file is not present in this project. Use the external copy https://developercertificate.org/.  This URL is also used by probot, https://github.com/apps/dco.

Alternatives considered:
- add a copy of the DCO to this project

-- 

The DCO probot is actively scanning this repository.

> 
![image](https://user-images.githubusercontent.com/317653/152162905-ac04305d-61ba-4cd2-a2aa-8d516019025f.png)
