### PR TITLE
Refactor test and release workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.vscode
+.golangci.yml
+deploy/
+dist/
+docs/
+**/.md
+*.md
+.gitignore
+Makefile

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for Go modules.
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for Docker images.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,8 +101,12 @@ jobs:
       id: should-push
       run: |
         SHOULD_PUSH=true
+        # Skip pushing if initiated by dependabot
         [[ "$GITHUB_ACTOR" == "dependabot[bot]" ]] && SHOULD_PUSH=false
+        # Skip pushing if a PR
         [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] && SHOULD_PUSH=false
+        # Skip pushing if a pull request and branch is not master
+        [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF_NAME" != "master" ]] && SHOULD_PUSH=false
         echo "::set-output name=should-push::${SHOULD_PUSH}"
 
     - name: Log in to ghcr.io

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,6 +102,7 @@ jobs:
       run: |
         SHOULD_PUSH=true
         [[ "$GITHUB_ACTOR" == "dependabot[bot]" ]] && SHOULD_PUSH=false
+        [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] && SHOULD_PUSH=false
         echo "::set-output name=should-push::${SHOULD_PUSH}"
 
     - name: Log in to ghcr.io

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,11 +4,11 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches:
-    - master
+    - '*'
+    - '!dependabot/**'
 
 env:
-  IMAGE_NAME: "equinix/cloud-provider-equinix-metal"
-
+  IMAGE_NAME: ${{ github.repository }}
 jobs:
   report:
     name: Report
@@ -18,44 +18,131 @@ jobs:
       run: echo ${{ github.ref }}
     - name: event_name
       run: echo ${{ github.event_name }}
-  build:
-    name: Build
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.17' # The Go version to download (if necessary) and use.
-    - name: ci
-      run: make ci
+        go-version: 1.17
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3.1.0
+      with:
+        version: v1.44.2
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    - id: go-cache-paths
+      shell: bash
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+    - name: Go Mod Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-mod-
+    - name: Go Build Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.go-cache-paths.outputs.go-build }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-build-
+
+    - name: test
+      run: make race
+
+  image:
+    name: Build Image
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
     - name: Set up QEMU for cross-building
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Build
-      id: docker_build
-      uses: docker/build-push-action@v2
-      with:
-        platforms: linux/amd64,linux/arm64
-        push: false
-        tags: |
-          ${{env.IMAGE_NAME}}:${{github.sha}}
 
-    # the rest of these only are used if we push to master
-    - name: Login to DockerHub
-      if: github.event_name == 'push' && endsWith(github.ref,'/master')
+    - name: Build image urls
+      id: image-urls
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      run: |
+        IMAGES=ghcr.io/${IMAGE_NAME}
+        [[ -n "$DOCKER_USERNAME" ]] && IMAGES=${IMAGES},${IMAGE_NAME}
+        [[ -n "$QUAY_USERNAME" ]] && IMAGES=${IMAGES},quay.io/${IMAGE_NAME}
+        echo "::set-output name=images::${IMAGES}"
+
+    - name: Docker manager metadata
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ steps.image-urls.outputs.images }}
+        tags: |
+          type=sha
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
+
+    - name: Determine if workflow should push image
+      id: should-push
+      run: |
+        SHOULD_PUSH=true
+        [[ "$GITHUB_ACTOR" == "dependabot[bot]" ]] && SHOULD_PUSH=false
+        echo "::set-output name=should-push::${SHOULD_PUSH}"
+
+    - name: Log in to ghcr.io
       uses: docker/login-action@v1
+      if: ${{ steps.should-push.outputs.should-push == 'true' }}
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Log into DockerHub
+      uses: docker/login-action@v1
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      if: ${{ env.DOCKER_USERNAME != '' && steps.should-push.outputs.should-push == 'true' }}
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Build and push  # theoretically, this builds what we did before, but with an unchanged dockerfile, it will just find everything in cache
-      id: docker_push
-      if: github.event_name == 'push' && endsWith(github.ref,'/master')
-      uses: docker/build-push-action@v2
+
+    - name: Log into quay.io
+      uses: docker/login-action@v1
+      env:
+        QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      if: ${{ env.QUAY_USERNAME != '' && steps.should-push.outputs.should-push == 'true' }}
       with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Build
+      id: docker_build
+      uses: docker/build-push-action@v2
+      env:
+        VERSION: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+      with:
+        context: .
+        push: ${{ steps.should-push.outputs.should-push == 'true' }}
+        build-args: |
+          BINARY=cloud-provider-equinix-metal
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/amd64,linux/arm64
-        push: true
-        tags: |
-          ${{env.IMAGE_NAME}}:${{github.sha}}
-          ${{env.IMAGE_NAME}}:master
+        cache-from: type=gha, scope=${{ github.workflow }}
+        cache-to: type=gha, mode=max, scope=${{ github.workflow }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     - 'v*'
 
 env:
-  IMAGE_NAME: "equinix/cloud-provider-equinix-metal"
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   images: # create images in docker hub
@@ -13,61 +13,120 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
-    - name: tagname
-      id: tagname
-      run: |
-        echo releasing ${GITHUB_REF#refs\/tags/}
-        echo ::set-output name=tag::${GITHUB_REF#refs\/tags/}
+      uses: actions/checkout@v3
     - name: Set up QEMU for cross-building
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
+
+    - name: Build image urls
+      id: image-urls
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      run: |
+        IMAGES=ghcr.io/${IMAGE_NAME}
+        [[ -n "$DOCKER_USERNAME" ]] && IMAGES=${IMAGES},${IMAGE_NAME}
+        [[ -n "$QUAY_USERNAME" ]] && IMAGES=${IMAGES},quay.io/${IMAGE_NAME}
+        echo "::set-output name=images::${IMAGES}"
+
+    - name: Docker manager metadata
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ steps.image-urls.outputs.images }}
+        tags: |
+          type=ref,event=tag
+
+    - name: Log in to ghcr.io
       uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Log into DockerHub
+      uses: docker/login-action@v1
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      if: ${{ env.DOCKER_USERNAME != '' }}
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Log into quay.io
+      uses: docker/login-action@v1
+      env:
+        QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      if: ${{ env.QUAY_USERNAME != '' }}
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
     - name: Build
       id: docker_build
       uses: docker/build-push-action@v2
+      env:
+        VERSION: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
       with:
-        platforms: linux/amd64,linux/arm64
+        context: .
         push: true
-        tags: |
-          ${{ format('{0}:{1}', env.IMAGE_NAME, steps.tagname.outputs.tag) }}
-          ${{ format('{0}:{1}', env.IMAGE_NAME, 'latest') }}
+        build-args: |
+          BINARY=cloud-provider-equinix-metal
+          LDFLAGS=-X 'k8s.io/component-base/version.gitVersion=${{ env.VERSION }}' -X 'k8s.io/component-base/version/verflag.programName=Cloud Provider Equinix Metal'
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64,linux/arm64
+        cache-from: type=gha, scope=${{ github.workflow }}
+        cache-to: type=gha, mode=max, scope=${{ github.workflow }}
 
   release: # create a github actions release with necessary artifacts
     name: Release
     runs-on: ubuntu-latest
+    needs:
+    - images
     steps:
-    - name: checkout
-      uses: actions/checkout@v2
-    - name: tagname
-      id: tagname
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Build image urls
+      id: image-urls
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       run: |
-        echo releasing ${GITHUB_REF#refs\/tags/}
-        echo ::set-output name=tag::${GITHUB_REF#refs\/tags/}
+        IMAGES=ghcr.io/${IMAGE_NAME}
+        [[ -n "$DOCKER_USERNAME" ]] && IMAGES=${IMAGES},${IMAGE_NAME}
+        [[ -n "$QUAY_USERNAME" ]] && IMAGES=${IMAGES},quay.io/${IMAGE_NAME}
+        echo "::set-output name=images::${IMAGES}"
+
+    - name: Docker manager metadata
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ steps.image-urls.outputs.images }}
+        tags: |
+          type=ref,event=tag
+
     - name: release template
-      run: cat deploy/template/deployment.yaml | sed 's/RELEASE_TAG/'${{ steps.tagname.outputs.tag }}'/g' > /tmp/deployment.yaml
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
+      env:
+        RELEASE_IMG: ghcr.io/${{ env.IMAGE_NAME }}:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+      run: cat deploy/template/deployment.yaml | sed 's#RELEASE_IMG#${{ env.RELEASE_IMG }}#g' > /tmp/deployment.yaml
+    - name: Generate Release Notes
+      run: |
+        release_notes=$(gh api repos/{owner}/{repo}/releases/generate-notes -F tag_name=${{ github.ref }} --jq .body)
+        echo 'RELEASE_NOTES<<EOF' >> $GITHUB_ENV
+        echo "${release_notes}" >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        OWNER: ${{ github.repository_owner }}
+        REPO: ${{ github.event.repository.name }}
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        files: /tmp/deployment.yaml
+        body: ${{ env.RELEASE_NOTES }}
         draft: false
         prerelease: false
-    - name: Upload Deployment Yaml Release Asset
-      id: upload-release-asset-deployment
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: /tmp/deployment.yaml
-        asset_name: deployment.yaml
-        asset_content_type: application/yaml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,4 +7,4 @@ linters:
 run:
   # Timeout for analysis, e.g. 30s, 5m.
   # Default: 1m
-  timeout: 2m
+  timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+linters:
+  disable-all: true
+  enable:
+  - gofmt
+  - govet
+  - revive
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 2m

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -11,7 +11,7 @@ fullnameOverride: ""
 
 image:
   # -- Name of the image repository to pull the container image from.
-  repository: equinix/cloud-provider-equinix-metal
+  repository: ghcr.io/equinix/cloud-provider-equinix-metal
 
   # -- [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node.
   pullPolicy: IfNotPresent

--- a/deploy/template/deployment.yaml
+++ b/deploy/template/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           effect: NoSchedule
           operator: Exists
       containers:
-      - image: equinix/cloud-provider-equinix-metal:RELEASE_TAG
+      - image: RELEASE_IMG
         name: cloud-provider-equinix-metal
         imagePullPolicy: Always
         command:


### PR DESCRIPTION
- Add support for multiple registries
- conditionalize registry logins and image pushes
- add dockerignore
- Cleanup image creation
- bump golangci-lint
- use golangci-lint for vet, use golangci github action for lint
- Add caching for ci/release workflows
- breakout lint, test, image as separate jobs
- cleanup makefile a bit more
- Add dependabot config
- Skip ci workflow on dependabot branches
- Update default image used by helm chart and deployment.yaml

Signed-off-by: Jason DeTiberus <detiber@users.noreply.github.com>