### PR TITLE
Enable the CCM to come up before node is ready so it can assign EIP.

### DIFF
--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
           operator: Exists
+        - key: "node.kubernetes.io/not-ready"
+          effect: NoSchedule
+          operator: Exists
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/deploy/template/deployment.yaml
+++ b/deploy/template/deployment.yaml
@@ -36,6 +36,10 @@ spec:
         - key: "node-role.kubernetes.io/control-plane"
           effect: NoSchedule
           operator: Exists
+        # Needed to let CCM come up and assign the EIP
+        - key: "node.kubernetes.io/not-ready"
+          effect: NoSchedule
+          operator: Exists
       containers:
       - image: RELEASE_IMG
         name: cloud-provider-equinix-metal


### PR DESCRIPTION
This PR adds a scheduling toleration for "node.kubernetes.io/not-ready". This is to enable the cloud provider to come up on the first control plane node of a brand new cluster and assign the EIP that will be used as the cluster's VIP for its API server. This behavior is needed for cluster-api style provisions without BGP.
