### PR TITLE
use native go cross-compiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,10 @@
 
 # Build the manager binary
 ARG GOVER=1.17.8
-FROM golang:${GOVER} as builder
+FROM --platform=$BUILDPLATFORM golang:${GOVER} as builder
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
 
 WORKDIR /workspace
 
@@ -31,10 +34,10 @@ RUN go mod download
 COPY . .
 
 # Build
-ARG ARCH
+ARG TARGETARCH
 ARG LDFLAGS
 ARG BINARY=cloud-provider-equinix-metal
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
     go build -a -ldflags "${LDFLAGS} -extldflags '-static'" \
     -o "${BINARY}" .
 


### PR DESCRIPTION
We call the builds by passing `--platforms` to the `docker buildx build`, whether directly or via the GitHub action `docker/build-push-action`.

Either way, this causes it to run every command under qemu, so that non-native builds take about 4-5x as long as the native ones. See a typical build and issue #257 .

This proposes to fix the biggest problem, i.e. those emulated builds. Instead of emulating the entire process, this will run the actual build (as well as `go mod download` and every other step except for image assembly) on the native platform, but cross-compiling.

Local tests show that the result is that building for both native and alternate platforms are within a few percentage points of each other. We will let CI run here and see what it reports.