### PR TITLE
fix ghcr.io org name for releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ env:
   GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
   DOCKER_REGISTRY: ${{ secrets.DOCKER_ORG }}
   QUAY_REGISTRY: quay.io/${{ secrets.QUAY_ORG }}
-  REGISTRY: ghcr.io/${{ secrets.QUAY_ORG }}
+  REGISTRY: ghcr.io/${{ github.repository_owner }}
   metadata_flavor: latest=false
   metadata_tags: |
     type=sha

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ env:
   GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
   DOCKER_REGISTRY: ${{ secrets.DOCKER_ORG }}
   QUAY_REGISTRY: quay.io/${{ secrets.QUAY_ORG }}
-  REGISTRY: ghcr.io/${{ secrets.QUAY_ORG }}
+  REGISTRY: ghcr.io/${{ github.repository_owner }}
   metadata_flavor: latest=true
   metadata_tags: type=ref,event=tag
 jobs:


### PR DESCRIPTION
We were using the `QUAY_ORG` instead of the ghcr org (which, by definition, is the `repository_owner`), so no one could pull it down.