### PR TITLE
include namespace in metallb address-pool name

### DIFF
--- a/metal/loadbalancers/metallb/metallb.go
+++ b/metal/loadbalancers/metallb/metallb.go
@@ -188,7 +188,7 @@ func updateMapIP(ctx context.Context, config *ConfigFile, addr, svcNamespace, sv
 		autoAssign := false
 		if !config.AddAddressPool(&AddressPool{
 			Protocol:   "bgp",
-			Name:       svcName,
+			Name:       fmt.Sprintf("%s/%s", svcNamespace, svcName),
 			Addresses:  []string{addr},
 			AutoAssign: &autoAssign,
 		}) {


### PR DESCRIPTION
Fixes #286 

We were including only the service name (without the namespace) when naming the address pool for metallb. This meant that if we created two services with the same name, but in different namespaces - which is completely legitimate from Kubernetes' perspective - only the first would work. The second would generate a metallb error.

This change includes the namespace and the name in metallb.

I ran tests, as well as went through the metallb code, and see no issues.