### PR TITLE
filter out controlplane EIP from loadbalancer services

### DIFF
--- a/metal/cloud.go
+++ b/metal/cloud.go
@@ -85,7 +85,7 @@ func (c *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 	if err != nil {
 		klog.Fatalf("could not initialize BGP: %v", err)
 	}
-	lb, err := newLoadBalancers(c.client, clientset, c.config.ProjectID, c.config.Metro, c.config.Facility, c.config.LoadBalancerSetting, bgp.localASN, bgp.bgpPass, c.config.AnnotationNetworkIPv4Private, c.config.AnnotationLocalASN, c.config.AnnotationPeerASN, c.config.AnnotationPeerIP, c.config.AnnotationSrcIP, c.config.AnnotationBGPPass, c.config.AnnotationEIPMetro, c.config.AnnotationEIPMetro, c.config.BGPNodeSelector)
+	lb, err := newLoadBalancers(c.client, clientset, c.config.ProjectID, c.config.Metro, c.config.Facility, c.config.LoadBalancerSetting, bgp.localASN, bgp.bgpPass, c.config.AnnotationNetworkIPv4Private, c.config.AnnotationLocalASN, c.config.AnnotationPeerASN, c.config.AnnotationPeerIP, c.config.AnnotationSrcIP, c.config.AnnotationBGPPass, c.config.AnnotationEIPMetro, c.config.AnnotationEIPMetro, c.config.BGPNodeSelector, c.config.EIPTag)
 	if err != nil {
 		klog.Fatalf("could not initialize LoadBalancers: %v", err)
 	}


### PR DESCRIPTION
Fixes #258 

When the control plane EIP is managed by CCM, it also creates a service of `type=LoadBalancer`. This makes sense. But it also causes the loadbalancer logic to trigger, adding it to any load balancers. This, in turn, can cause BGP to kick in.

The fix is to filter out the specific service for the control plane.