### PR TITLE
switch to DaemonSet to run on all control plane nodes

### DIFF
--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: {{ include "cloud-provider-equinix-metal.fullname" . }}
   labels:
@@ -17,7 +17,6 @@ spec:
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "cloud-provider-equinix-metal.selectorLabels" . | nindent 8 }}
@@ -28,6 +27,7 @@ spec:
       {{- end }}
       dnsPolicy: Default
       hostNetwork: true
+      priorityClassName: system-cluster-critical
       serviceAccountName: {{ include "cloud-provider-equinix-metal.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -35,6 +35,25 @@ spec:
       hostAliases: 
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      # set node affinity such that it will run only on nodes that have one of (logical OR)
+      # the labels:
+      #   kubernetes.io/role: master
+      #   node-role.kubernetes.io/control-plane
+      #   node-role.kubernetes.io/master
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/role
+                operator: In
+                values: [master]
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       tolerations:
         - key: node.cloudprovider.kubernetes.io/uninitialized
           value: 'true'

--- a/deploy/template/deployment.yaml
+++ b/deploy/template/deployment.yaml
@@ -1,13 +1,12 @@
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: cloud-provider-equinix-metal
   namespace: kube-system
   labels:
     app: cloud-provider-equinix-metal
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: cloud-provider-equinix-metal
@@ -15,12 +14,30 @@ spec:
     metadata:
       labels:
         app: cloud-provider-equinix-metal
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       dnsPolicy: Default
       hostNetwork: true
+      priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
+      # set node affinity such that it will run only on nodes that have one of (logical OR)
+      # the labels:
+      #   kubernetes.io/role: master
+      #   node-role.kubernetes.io/control-plane
+      #   node-role.kubernetes.io/master
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/role
+                operator: In
+                values: [master]
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       tolerations:
         # this taint is set by all kubelets running `--cloud-provider=external`
         # so we should tolerate it to schedule the Equinix Metal ccm


### PR DESCRIPTION
Partially addresses #304, specifically the second issue raised.

Rather than running it as a `Deployment` with `replicas=1`, we run this as a `DaemonSet` with `nodeAffinity` restricting it to control plane nodes. This means that if you have 3 such nodes, you will get 3 copies.

The built-in leader election of k8s.io/cloud-provider ensures that only one processes events at a time.

If you have multiple (as this provides), and one dies (of greater concern, the node it is running on dies, taking CPEM with it), then one of the remaining ones will take over quickly, and work will continue as normal. This includes the important part of letting the apiserver know that the node is gone, which is a CPEM responsibility.

**Important note::** This does _not_ solve the issue of the node that dies being host both to the CPEM (whether lone before this PR or current leader after this PR) _and_ the EIP (when using an EIP managed by CPEM for apiserver access. In that case, this will not help. As the node goes down, so does CPEM, so nothing can switch the EIP to a functioning node. That is CPEM's responsibility, but it is down, too. Leader election would help, but leader election depends on access to the k8s apiserver, which depends on the EIP, which points to the node that just went down.

That will need to be addressed via some other solution; see the tracking issue linked at the beginning.

---
Separately, while also dealing with the deployment templates, it also fixes a deprecated annotation. This used to exist:

```yaml
      annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
```

But has been deprecated since 1.16. The replacement to use:

```yaml
priorityClassName: system-cluster-critical
```

as part of the podspec has been adopted.