### PR TITLE
enable leader-elect

### DIFF
--- a/deploy/chart/templates/clusterrole.yaml
+++ b/deploy/chart/templates/clusterrole.yaml
@@ -82,4 +82,15 @@ rules:
       - watch
       - update
       - patch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
 {{- end }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
           command:
             - ./cloud-provider-equinix-metal
             - '--cloud-provider=equinixmetal'
-            - '--leader-elect=false'
+            - '--leader-elect=true'
             - '--authentication-skip-lookup=true'
             - '--cloud-config=/etc/cloud-sa/cloud-sa.json'
           {{- with .Values.additionalCommands }}

--- a/deploy/template/deployment.yaml
+++ b/deploy/template/deployment.yaml
@@ -64,7 +64,7 @@ spec:
         command:
           - "./cloud-provider-equinix-metal"
           - "--cloud-provider=equinixmetal"
-          - "--leader-elect=false"
+          - "--leader-elect=true"
           - "--authentication-skip-lookup=true"
           - "--cloud-config=/etc/cloud-sa/cloud-sa.json"
         resources:
@@ -166,6 +166,18 @@ rules:
   - ""
   resources:
   - events
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  # reason: so ccm can use leases
+  - "coordination.k8s.io"
+  resources:
+  - leases
   verbs:
   - create
   - get


### PR DESCRIPTION
For reasons lost in the mists of time, CPEM had `--leader-elect=false` on the its CLI flags. This disabled leader-elect.

This PR:

1. Sets it to `true`
2. Adds the necessary `ClusterRole` permissions

