### PR TITLE
rename deployment.yaml to daemonset.yaml in Helm and remove extraneous field

### DIFF
--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "cloud-provider-equinix-metal.labels" . | nindent 4 }}
 spec:
-  replicas: 1
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
Fixes #312 

I debated changing the `deploy/template/deployment.yaml` file as well, but that wasn't named for `Deployment` as much as "this contains all of the things to deploy, including RBAC and `Deployment` (now a `DaemonSet`) etc. So I left that one alone.