### PR TITLE
metallb support range

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ If `kube-vip` management is enabled, then CCM does the following.
 
 ##### MetalLB
 
-**Minimum Version**: MetalLB [version 0.11.0](https://metallb.universe.tf/release-notes/#version-0-11-0)
+**Supported Versions**: MetalLB [version 0.11.0](https://metallb.universe.tf/release-notes/#version-0-11-0) through [version 0.12.1](https://metallb.universe.tf/release-notes/#version-0-12-1). We are in the process of adding support for version 0.13.x.
 
 When [MetalLB](https://metallb.universe.tf) is enabled, for user-deployed Kubernetes `Service` of `type=LoadBalancer`,
 the Equinix Metal CCM uses BGP and to provide the _equivalence_ of load balancing, without


### PR DESCRIPTION
metallb 0.13.x changes several things, to the point that CPEM doesn't work correctly with it.

This does **not** fix it, but does indicate in the README which versions are supported.

When we are ready to support it, we will update these comments.