### PR TITLE
bump golangci-lint to 1.51 in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3.4.0
       with:
-        version: v1.48
+        version: v1.51
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>