### PR TITLE
replace set-output with output environment file

### DIFF
--- a/.github/actions/metadata/action.yaml
+++ b/.github/actions/metadata/action.yaml
@@ -36,7 +36,7 @@ runs:
       IMAGES=${GHCR_REGISTRY}/${IMAGE_NAME}
       [[ -n "$DOCKER_USERNAME" ]] && IMAGES=${IMAGES},${DOCKER_REGISTRY}/${IMAGE_NAME}
       [[ -n "$QUAY_USERNAME" ]] && IMAGES=${IMAGES},${QUAY_REGISTRY}/${IMAGE_NAME}
-      echo "::set-output name=images::${IMAGES}"
+      echo "images=${IMAGES}" >> $GITHUB_OUTPUT
   - name: Docker manager metadata
     id: meta
     uses: docker/metadata-action@v3


### PR DESCRIPTION
Same as #372 but for action.yaml which I overlooked before.

Our CI is using deprecated functionality for saving outputs. We need to convert to using environment files or our workflows will stop working later this year.

Details are here: 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>