### PR TITLE
Bump metadata-action version

### DIFF
--- a/.github/actions/metadata/action.yaml
+++ b/.github/actions/metadata/action.yaml
@@ -39,7 +39,7 @@ runs:
       echo "::set-output name=images::${IMAGES}"
   - name: Docker manager metadata
     id: meta
-    uses: docker/metadata-action@v3
+    uses: docker/metadata-action@v4
     with:
       images: ${{ steps.image-urls.outputs.images }}
       flavor: ${{ inputs.metadata_flavor }}


### PR DESCRIPTION
The old version of the metadata-action relied on node.js:12 which is EOL and will be breaking soon.

Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>