### PR TITLE
fix: correctly use the eip facility annotation

### DIFF
--- a/metal/cloud.go
+++ b/metal/cloud.go
@@ -84,7 +84,7 @@ func (c *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 	if err != nil {
 		klog.Fatalf("could not initialize BGP: %v", err)
 	}
-	lb, err := newLoadBalancers(c.client, clientset, c.config.ProjectID, c.config.Metro, c.config.Facility, c.config.LoadBalancerSetting, bgp.localASN, bgp.bgpPass, c.config.AnnotationNetworkIPv4Private, c.config.AnnotationLocalASN, c.config.AnnotationPeerASN, c.config.AnnotationPeerIP, c.config.AnnotationSrcIP, c.config.AnnotationBGPPass, c.config.AnnotationEIPMetro, c.config.AnnotationEIPMetro, c.config.BGPNodeSelector, c.config.EIPTag)
+	lb, err := newLoadBalancers(c.client, clientset, c.config.ProjectID, c.config.Metro, c.config.Facility, c.config.LoadBalancerSetting, bgp.localASN, bgp.bgpPass, c.config.AnnotationNetworkIPv4Private, c.config.AnnotationLocalASN, c.config.AnnotationPeerASN, c.config.AnnotationPeerIP, c.config.AnnotationSrcIP, c.config.AnnotationBGPPass, c.config.AnnotationEIPMetro, c.config.AnnotationEIPFacility, c.config.BGPNodeSelector, c.config.EIPTag)
 	if err != nil {
 		klog.Fatalf("could not initialize LoadBalancers: %v", err)
 	}


### PR DESCRIPTION
Fix the load balancer ignoring the EIP facilicy selection annotation by actually passing the correct annotation configuration to the new load balancer function.

Fixes #409